### PR TITLE
fix usage of system iptables

### DIFF
--- a/src/org/torproject/android/service/TorTransProxy.java
+++ b/src/org/torproject/android/service/TorTransProxy.java
@@ -80,28 +80,21 @@ public class TorTransProxy implements TorServiceConstants {
 	
 	private String findSystemIPTables ()
 	{
-		if (mSysIptables != null)
-		{
-			return mSysIptables;
-		}
+
+		//if the user wants us to use the built-in iptables, then we have to find it
+		File fileIpt = new File("/system/xbin/iptables");
+
+		if (fileIpt.exists())
+			mSysIptables = fileIpt.getAbsolutePath();
 		else
 		{
-		
-			//if the user wants us to use the built-in iptables, then we have to find it
-			File fileIpt = new File("/system/xbin/iptables");
-			
+
+			fileIpt = new File("/system/bin/iptables");
+
 			if (fileIpt.exists())
 				mSysIptables = fileIpt.getAbsolutePath();
-			else
-			{
-			
-				fileIpt = new File("/system/bin/iptables");
-				
-				if (fileIpt.exists())
-					mSysIptables = fileIpt.getAbsolutePath();
-			}
 		}
-		
+
 		return mSysIptables;
 	}
 	


### PR DESCRIPTION
As findSystemIP6Tables sets mSysIptables, iptables for ipv4 get never used.
