### PR TITLE
Fix 'Transparent Proxying' (not) enabling in rooted devices after 'Request Root Access' checkbox changes

### DIFF
--- a/src/org/torproject/android/settings/SettingsPreferences.java
+++ b/src/org/torproject/android/settings/SettingsPreferences.java
@@ -148,8 +148,6 @@ public class SettingsPreferences
 						shell.close();
 						
 						prefRequestRoot.setChecked(true);
-						prefCBTransProxy.setEnabled(true);
-						
 					}
 					catch (Exception e)
 					{
@@ -157,6 +155,8 @@ public class SettingsPreferences
 					}
 				}
 			}
+
+			prefCBTransProxy.setEnabled(prefRequestRoot.isChecked());
 		}
 		else if (preference == prefTransProxyApps)
 		{


### PR DESCRIPTION
Hi,
I modified the code to let the checkbox "Transparent Proxying" be enabled or disabled after the checkbox "Request Root Access" changes its value.
Before the checkbox were enabled only if the flow went into the "if" statement, and this happend only if the device wasn't rooted.
Setting "Request Root Access" to "unchecked" before didn't disable "Transparent Proxying" checkbox, now it disable it.

Thanks,
Luca
