### PR TITLE
Update ant build

### DIFF
--- a/jenkins-build
+++ b/jenkins-build
@@ -1,11 +1,13 @@
 #!/bin/bash
+# bash is required because we need bash's printf to guarantee a cross-platform
+# timestamp format.
 
 set -e
 set -x
 
 if [ -z $ANDROID_HOME ]; then
-    if [ -e ~/.android/bashrc ]; then
-        . ~/.android/bashrc
+    if [ -e ~/.android/bashrc-ant-build ]; then
+        . ~/.android/bashrc-ant-build
     else
         echo "ANDROID_HOME must be set!"
         exit

--- a/make-release-build
+++ b/make-release-build
@@ -27,8 +27,8 @@ fi
 
 
 if [ -z $ANDROID_HOME ]; then
-    if [ -e ~/.android/bashrc ]; then
-        . ~/.android/bashrc
+    if [ -e ~/.android/bashrc-ant-build ]; then
+        . ~/.android/bashrc-ant-build
     else
         echo "ANDROID_HOME must be set!"
         exit

--- a/src/org/torproject/android/service/TorService.java
+++ b/src/org/torproject/android/service/TorService.java
@@ -698,7 +698,9 @@ public class TorService extends VpnService implements TorServiceConstants, Orbot
     /**
      * Send Orbot's status in reply to an
      * {@link TorServiceConstants#ACTION_START} {@link Intent}, targeted only to
-     * the app that sent the initial request.
+     * the app that sent the initial request. If the user has disabled auto-
+     * starts, the reply {@code ACTION_START Intent} will include the extra
+     * {@link TorServiceConstants#STATUS_STARTS_DISABLED}
      */
     private void replyWithStatus(Intent startRequest) {
         String packageName = startRequest.getStringExtra(EXTRA_PACKAGE_NAME);

--- a/src/org/torproject/android/service/TorServiceConstants.java
+++ b/src/org/torproject/android/service/TorServiceConstants.java
@@ -117,9 +117,11 @@ public interface TorServiceConstants {
     public final static String STATUS_ON = "ON";
     public final static String STATUS_STARTING = "STARTING";
     public final static String STATUS_STOPPING = "STOPPING";
+
     /**
      * The user has disabled the ability for background starts triggered by
-     * apps. Fallback to the old Intent that brings up Orbot.
+     * apps. Fallback to the old {@link Intent} action that brings up Orbot:
+     * {@link org.torproject.android.OrbotMainActivity#INTENT_ACTION_REQUEST_START_TOR}
      */
     public final static String STATUS_STARTS_DISABLED = "STARTS_DISABLED";
 


### PR DESCRIPTION
That dear old `ant` build, just needs a little tweak to work again, as long as you have a copy of the Android SDK that is frozen on the v23 tools :-)
