### PR TITLE
fixed crash when an user tries to add the same hidden service port twice

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -624,7 +624,7 @@ public class OrbotMainActivity extends AppCompatActivity
 
         if (row == null || row.getCount() < 1) {
             cr.insert(HSContentProvider.CONTENT_URI, fields);
-        } else {
+        } else if (row.moveToFirst()) {
             onionHostname = row.getString(row.getColumnIndex(HSContentProvider.HiddenService.DOMAIN));
             row.close();
         }


### PR DESCRIPTION
without this check the app will throw a CursorIndexOutOfBoundsException