### PR TITLE
Expose *ConnectionPadding

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,4 +384,8 @@
   <string name="pref_isolate_dest_summary">Use a different circuit for each destination address</string>
   <string name="no_transproxy_warning_short">WARNING: Transproxying no longer supported</string>
   <string name="no_transproxy_warning">WARNING: Transparent proxying not supported. Use Orbot Apps VPN instead.</string>
+  <string name="pref_connection_padding">Connection padding</string>
+  <string name="pref_connection_padding_summary">Always enables connection padding to defend against some forms of traffic analysis. Default: auto</string>
+  <string name="pref_reduced_connection_padding">Reduced connection padding</string>
+  <string name="pref_reduced_connection_padding_summary">Closes relay connections sooner and sends less padding packets to reduce data and battery usage</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -166,6 +166,22 @@ android:summary="@string/pref_isolate_dest_summary"
 android:enabled="true"></CheckBoxPreference>
 </PreferenceCategory>
 
+<PreferenceCategory android:title="ConnectionPadding">
+<CheckBoxPreference
+android:key="pref_connection_padding"
+android:defaultValue="false"
+android:title="@string/pref_connection_padding"
+android:summary="@string/pref_connection_padding_summary"
+android:enabled="true"></CheckBoxPreference>
+<CheckBoxPreference
+android:key="pref_reduced_connection_padding"
+android:defaultValue="true"
+android:title="@string/pref_reduced_connection_padding"
+android:summary="@string/pref_reduced_connection_padding_summary"
+android:enabled="true"></CheckBoxPreference>
+</PreferenceCategory>
+
+
 <PreferenceCategory android:title="@string/pref_proxy_title">
 <EditTextPreference android:key="pref_proxy_type"
 android:title="@string/pref_proxy_type_title"

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
@@ -36,4 +36,7 @@ public interface OrbotConstants {
 
 	public final static String PREF_ISOLATE_DEST = "pref_isolate_dest";
 
+	public final static String PREF_CONNECTION_PADDING = "pref_connection_padding";
+	public final static String PREF_REDUCED_CONNECTION_PADDING = "pref_reduced_connection_padding";
+
 }

--- a/orbotservice/src/main/java/org/torproject/android/service/TorService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorService.java
@@ -672,6 +672,15 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
         extraLines.append("TestSocks 0").append('\n');
         extraLines.append("WarnUnsafeSocks 1").append('\n');
 
+	if(prefs.getBoolean(OrbotConstants.PREF_CONNECTION_PADDING, false))
+	{
+		extraLines.append("ConnectionPadding 1").append('\n');
+	}
+	if(prefs.getBoolean(OrbotConstants.PREF_REDUCED_CONNECTION_PADDING, true))
+	{
+		extraLines.append("ReducedConnectionPadding 1").append('\n');
+	}
+
         String transPort = prefs.getString("pref_transport", TorServiceConstants.TOR_TRANSPROXY_PORT_DEFAULT+"");
         String dnsPort = prefs.getString("pref_dnsport", TorServiceConstants.TOR_DNS_PORT_DEFAULT+"");
             


### PR DESCRIPTION
This exposes 'ConnectionPadding' and 'ReducedConnectionPadding' options as recommended by the Tor man page.

> This option should be offered via the UI to mobile users for use where bandwidth may be expensive.

It also enables 'ReducedConnectionPadding' by default as to save battery and keep idle data usage low.