### PR TITLE
Add new preference: pref_open_proxy_on_all_interfaces

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,6 +128,8 @@
   <string name="pref_entrance_node_dialog">Enter Entrance Nodes</string>
   <string name="pref_allow_background_starts_title">Allow Background Starts</string>
   <string name="pref_allow_background_starts_summary">Let any app tell Orbot to start Tor and related services</string>
+  <string name="pref_open_proxy_on_all_interfaces_title">Open Proxy on All Interfaces</string>
+  <string name="pref_open_proxy_on_all_interfaces_summary">Allow Wifi peers, tethered devices and anyone else who can connect to your IP, to access Tor</string>
 
   <string name="button_proxy_all">Proxy All</string>
   <string name="button_proxy_none">Proxy None</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -28,6 +28,12 @@ android:key="pref_allow_background_starts"
 android:summary="@string/pref_allow_background_starts_summary"
 android:title="@string/pref_allow_background_starts_title"/>
 
+<CheckBoxPreference
+android:defaultValue="false"
+android:key="pref_open_proxy_on_all_interfaces"
+android:summary="@string/pref_open_proxy_on_all_interfaces_summary"
+android:title="@string/pref_open_proxy_on_all_interfaces_title"/>
+
  <ListPreference android:title="@string/set_locale_title"
    android:key="pref_default_locale"
    android:summary="@string/set_locale_summary"

--- a/orbotservice/src/main/java/org/torproject/android/service/TorService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorService.java
@@ -659,6 +659,8 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
         extraLines.append("SafeSocks 0").append('\n');
         extraLines.append("TestSocks 0").append('\n');
         extraLines.append("WarnUnsafeSocks 1").append('\n');
+    	if (Prefs.openProxyOnAllInterfaces())
+    		extraLines.append("SocksListenAddress 0.0.0.0").append('\n');
 
 	if(prefs.getBoolean(OrbotConstants.PREF_CONNECTION_PADDING, false))
 	{

--- a/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
@@ -17,6 +17,7 @@ public class Prefs {
     private final static String PREF_PERSIST_NOTIFICATIONS = "pref_persistent_notifications";
     private final static String PREF_START_ON_BOOT = "pref_start_boot";
     private final static String PREF_ALLOW_BACKGROUND_STARTS = "pref_allow_background_starts";
+    private final static String PREF_OPEN_PROXY_ON_ALL_INTERFACES = "pref_open_proxy_on_all_interfaces";
     private final static String PREF_TRANSPARENT = "pref_transparent";
     private final static String PREF_TRANSPARENT_ALL = "pref_transparent_all";
     private final static String PREF_TRANSPARENT_TETHERING = "pref_transparent_tethering";
@@ -106,6 +107,10 @@ public class Prefs {
 
     public static boolean allowBackgroundStarts() {
         return prefs.getBoolean(PREF_ALLOW_BACKGROUND_STARTS, true);
+    }
+
+    public static boolean openProxyOnAllInterfaces() {
+        return prefs.getBoolean(PREF_OPEN_PROXY_ON_ALL_INTERFACES, false);
     }
 
     public static boolean useVpn() {


### PR DESCRIPTION
If set, this configures Tor to listen on 0.0.0.0 instead of 127.0.0.1.

The primary use-case for this, is to share Orbot with tethered devices or others on the same LAN. This is particularly useful when trying to access the Internet using a mobile plan that restricts or blocks tethered devices.

Without this patch, I would have had no useful Internet access from my laptop this Christmas...!  Filed in the hopes it will prove useful to others as well. Apologies in advance if this is the wrong venue for this sort of thing. Thanks for Orbot!