### PR TITLE
Fix lost asset:

### DIFF
--- a/orbotservice/src/main/jni/Android.mk
+++ b/orbotservice/src/main/jni/Android.mk
@@ -31,6 +31,13 @@ LOCAL_CFLAGS    := -Wall -O2 -I$(LOCAL_PATH)/pdnsd -DHAVE_STPCPY
 
 include $(BUILD_EXECUTABLE)
 
+.PHONY: $(CopyToAssets)
+
+CopyToAssets: libs/armeabi/pdnsd
+    $(shell mkdir -p assets/armeabi)
+    $(shell zip assets/armeabi/pdnsd.mp3 libs/armeabi/pdnsd)
+
+
 ########################################################
 ## libancillary
 ########################################################


### PR DESCRIPTION
* Modify Android.mk to zip and move pdnsd to the assets folder

Moving and zipping the assets was done in external/Makefile which is now gone. This is one possibility to fix this :)

Partly fixes #121 

Signed-off-by: goapunk <noobie@goapunks.net>