### PR TITLE
Some UI String Fixes

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -521,14 +521,14 @@ public class OrbotMainActivity extends AppCompatActivity
             .show();
         }
 
-    public static String readFromAssets(Context context, String filename) throws IOException {
+    private static String readFromAssets(Context context, String filename) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(context.getAssets().open(filename)));
 
         // do reading, usually loop until end of file reading
         StringBuilder sb = new StringBuilder();
         String mLine = reader.readLine();
         while (mLine != null) {
-            sb.append(mLine); // process line
+            sb.append(mLine + '\n'); // process line
             mLine = reader.readLine();
         }
         reader.close();

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -116,7 +116,7 @@
   <string name="wizard_transproxy_hint">(Dediklərimizdən heç biri haqqında xəbərin yoxdursa, qutunu işarələ)</string>
   <string name="wizard_transproxy_none">Heç biri</string>
   <string name="pref_transparent_tethering_title">Tor-un Son Həddi</string>
-  <string name="pref_transparent_tethering_summary">Wifi və USB ilə Bağlanan Cihazlar üçün Tor Şəffaf Proksiləməni Aktivləşdir (cihazın yenidən yüklənməsini tələb edir)</string>
+  <string name="pref_transparent_tethering_summary">Wi-Fi və USB ilə Bağlanan Cihazlar üçün Tor Şəffaf Proksiləməni Aktivləşdir (cihazın yenidən yüklənməsini tələb edir)</string>
   <string name="button_grant_superuser">Superistifadəçi Giriş Tələbi</string>
   <string name="pref_select_apps">Aplikasiya Seç</string>
   <string name="pref_select_apps_summary">Tor vasitəsilə açılması üçün Aplikasiya seç</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Избери тази опция ако нямаш представа за какво става въпрос)</string>
   <string name="wizard_transproxy_none">Нищо</string>
   <string name="pref_transparent_tethering_title">Тетъринг през Тор</string>
-  <string name="pref_transparent_tethering_summary">Включи Прозрачно Тор Проксифициране през Wifi и USB (изисква рестартирване)</string>
+  <string name="pref_transparent_tethering_summary">Включи Прозрачно Тор Проксифициране през Wi-Fi и USB (изисква рестартирване)</string>
   <string name="button_grant_superuser">Изискай достъп на Суперпотребител</string>
   <string name="pref_select_apps">Избери приложения</string>
   <string name="pref_select_apps_summary">Избрери приложения за използване през Тор</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Marqueu aquesta casella si no teniu ni idea del que estem parlant)</string>
   <string name="wizard_transproxy_none">Cap</string>
   <string name="pref_transparent_tethering_title">Compartició de xarxa amb Tor</string>
-  <string name="pref_transparent_tethering_summary">Activa el servidor intermediari transparent de Tor pels dispositius connectats a través de la compartició de xarxa via Wifi o USB (cal reiniciar)</string>
+  <string name="pref_transparent_tethering_summary">Activa el servidor intermediari transparent de Tor pels dispositius connectats a través de la compartició de xarxa via Wi-Fi o USB (cal reiniciar)</string>
   <string name="button_grant_superuser">Petició d\'accés de superusuari</string>
   <string name="pref_select_apps">Selecciona les apps</string>
   <string name="pref_select_apps_summary">Trieu quines apps s\'han de canalitzar a través de Tor</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -114,7 +114,7 @@
   <string name="wizard_transproxy_hint">(Povolte tuto volbu, pokud nemáte ponětí, o co se jedná)</string>
   <string name="wizard_transproxy_none">Žádné</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Povolit Tor transparentní proxy pro zařízení připojená přes Wifi a USB tethering (vyžaduje restart)</string>
+  <string name="pref_transparent_tethering_summary">Povolit Tor transparentní proxy pro zařízení připojená přes Wi-Fi a USB tethering (vyžaduje restart)</string>
   <string name="button_grant_superuser">Požadavek na Superuživatelský přístup</string>
   <string name="pref_select_apps">Vybrat aplikace</string>
   <string name="pref_select_apps_summary">Zvolte aplikace používající směrováni přes Tor</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -102,7 +102,7 @@
   <string name="wizard_transproxy_hint">(Check denne boks hvis du ikke aner hvad vi snakker om)</string>
   <string name="wizard_transproxy_none">Ingen</string>
   <string name="pref_transparent_tethering_title">Tor internet-hotspot</string>
-  <string name="pref_transparent_tethering_summary">Start Tor gennemsigtig proxy for Wifi og internetdeling over USB (kræver genstart)</string>
+  <string name="pref_transparent_tethering_summary">Start Tor gennemsigtig proxy for Wi-Fi og internetdeling over USB (kræver genstart)</string>
   <string name="button_grant_superuser">Anmod om Superuser adgang</string>
   <string name="pref_select_apps">Vælg apps</string>
   <string name="pref_select_apps_summary">Vælg apps som føres gennem Tor</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Επιλέξτε αυτό το τετράγωνο αν δεν καταλαβαίνετε για τι πράγμα μιλάμε)</string>
   <string name="wizard_transproxy_none">Καμία</string>
   <string name="pref_transparent_tethering_title">Διασύνδεση Tor</string>
-  <string name="pref_transparent_tethering_summary">Ενεργοποίηση της Διαφανούς μεσολάβησης διακομιστή για συσκευές με WiFi και διασύνδεση USB (απαιτεί επανεκκίνηση)</string>
+  <string name="pref_transparent_tethering_summary">Ενεργοποίηση της Διαφανούς μεσολάβησης διακομιστή για συσκευές με Wi-Fi και διασύνδεση USB (απαιτεί επανεκκίνηση)</string>
   <string name="button_grant_superuser">Αίτημα Πρόσβασης Υπερχρήστη</string>
   <string name="pref_select_apps">Επιλογή εφαρμογών</string>
   <string name="pref_select_apps_summary">Επιλέξτε τις εφαρμογές που θα διέλθουν μέσω Tor</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Marque esta casilla si no tiene idea de lo que estamos hablando)</string>
   <string name="wizard_transproxy_none">ninguno</string>
   <string name="pref_transparent_tethering_title">Anclaje a red Tor</string>
-  <string name="pref_transparent_tethering_summary">Activar Tor Proxy transparente para dispositivos Wifi y USB conectados (requiere reiniciar)</string>
+  <string name="pref_transparent_tethering_summary">Activar Tor Proxy transparente para dispositivos Wi-Fi y USB conectados (requiere reiniciar)</string>
   <string name="button_grant_superuser">Solicitar acceso Superusuario</string>
   <string name="pref_select_apps">seleccionar aplicaciones</string>
   <string name="pref_select_apps_summary">Elija aplicaciones para rutear a través de Tor</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Marque esta casilla si no tiene idea de qué estamos hablando)</string>
   <string name="wizard_transproxy_none">Ninguno</string>
   <string name="pref_transparent_tethering_title">Tor tethering</string>
-  <string name="pref_transparent_tethering_summary">Habilita la proxyficación transparente de Tor para dispositivos tethered (dispositivos móviles \"amarrados\", pasarela a Internet para otros dispositivos conectados a ellos mediante Wifi, USB o Bluetooth) -- (requiere reinicio)</string>
+  <string name="pref_transparent_tethering_summary">Habilita la proxyficación transparente de Tor para dispositivos tethered (dispositivos móviles \"amarrados\", pasarela a Internet para otros dispositivos conectados a ellos mediante Wi-Fi, USB o Bluetooth) -- (requiere reinicio)</string>
   <string name="button_grant_superuser">Solicitar permisos de superusuario</string>
   <string name="pref_select_apps">Seleccionar aplicaciones</string>
   <string name="pref_select_apps_summary">Escoja las aplicaciones a redirigir través de Tor</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -101,7 +101,7 @@
   <string name="wizard_transproxy_hint">(Klikkige sellele kastile kui teil pole õrna aimugi millest jutt käib)</string>
   <string name="wizard_transproxy_none">Puudub</string>
   <string name="pref_transparent_tethering_title">Tor lõastamine</string>
-  <string name="pref_transparent_tethering_summary">Luba Tor Läbipaistev Proxy WiFi ja USB lõastatud seadmetele (vajab uuestilaadimist)</string>
+  <string name="pref_transparent_tethering_summary">Luba Tor Läbipaistev Proxy Wi-Fi ja USB lõastatud seadmetele (vajab uuestilaadimist)</string>
   <string name="button_grant_superuser">Nõua Superkasutaja Juurdepääsu</string>
   <string name="pref_select_apps">Vali Rakendused</string>
   <string name="pref_select_apps_summary">Vali läbi Tor suunatavad rakendused</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -106,7 +106,7 @@
   <string name="wizard_transproxy_hint">(Gaituta utzi zertaz ari garez ulertzen ez baduzu)</string>
   <string name="wizard_transproxy_none">Bat ere ez</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Gaitu proxy gardena Wifi eta USB bidez Tethering-atutako gailuentzat (berrabiaraztea beharrezkoa)</string>
+  <string name="pref_transparent_tethering_summary">Gaitu proxy gardena Wi-Fi eta USB bidez Tethering-atutako gailuentzat (berrabiaraztea beharrezkoa)</string>
   <string name="button_grant_superuser">Supererabiltzaile sarrera eskatu</string>
   <string name="pref_select_apps">Aplikazioak hautatu</string>
   <string name="pref_select_apps_summary">Tor bidez bideratuko diren aplikazioak hautatu</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Rastita tämä ruutu, jos et tiedä, mitä tarkoitamme)</string>
   <string name="wizard_transproxy_none">Ei mikään</string>
   <string name="pref_transparent_tethering_title">Tor-välityspalvelimena oleminen</string>
-  <string name="pref_transparent_tethering_summary">Salli Torin läpinäkyvä tiedonvälitys Wifille ja USB-välityspalvelimena oleville laitteille (vaatii uudelleenkäynnistyksen)</string>
+  <string name="pref_transparent_tethering_summary">Salli Torin läpinäkyvä tiedonvälitys Wi-Fille ja USB-välityspalvelimena oleville laitteille (vaatii uudelleenkäynnistyksen)</string>
   <string name="button_grant_superuser">Pyydä Superuser-oikeuksia</string>
   <string name="pref_select_apps">Valitse sovellukset</string>
   <string name="pref_select_apps_summary">Valitse Torin läpi reititettävät sovellukset</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -109,7 +109,7 @@ http://tinyurl.com/proxyandroid\n </string>
   <string name="wizard_transproxy_hint">(Marque esta caixa se non ten nin idea do que lle estamos a falar)</string>
   <string name="wizard_transproxy_none">Ningunha</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente Tor para dispositivos enlazados por Wifi ou USB (require reiniciar)</string>
+  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente Tor para dispositivos enlazados por Wi-Fi ou USB (require reiniciar)</string>
   <string name="button_grant_superuser">Pedir Acceso de Superusuario</string>
   <string name="pref_select_apps">Seleccionar Aplicativos</string>
   <string name="pref_select_apps_summary">Elixir Aplicativos a Enrutar a Través de Tor</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -126,7 +126,7 @@ Tor עוזר בלהגן מ traffic analysis ,content filtering ו- network surve
   <string name="wizard_transproxy_hint">(סמן תיבה זו אם אין לך מושג על מה אנחנו מדברים)</string>
   <string name="wizard_transproxy_none">כלום</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">אפשר ייפוי כוח שקוף של Tor עבור WiFi ומכשירים מחוברי USB (דורש הפעלה מחדש)</string>
+  <string name="pref_transparent_tethering_summary">אפשר ייפוי כוח שקוף של Tor עבור Wi-Fi ומכשירים מחוברי USB (דורש הפעלה מחדש)</string>
   <string name="button_grant_superuser">דרוש אישור Superuser</string>
   <string name="pref_select_apps">בחר אפלקציות</string>
   <string name="pref_select_apps_summary">בחר אפלקציות</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Stavite kvačicu ako nemate pojma o čemu pričamo)</string>
   <string name="wizard_transproxy_none">Ništa</string>
   <string name="pref_transparent_tethering_title">Tor Privezanje</string>
-  <string name="pref_transparent_tethering_summary">Omogući Tor Transparentni Proxy za Wifi i USB privezane uređaje (zahtijeva ponovno pokretanje)</string>
+  <string name="pref_transparent_tethering_summary">Omogući Tor Transparentni Proxy za Wi-Fi i USB privezane uređaje (zahtijeva ponovno pokretanje)</string>
   <string name="button_grant_superuser">Zatraži Pristup Superuser-u</string>
   <string name="pref_select_apps">Odaberi Aplikacije</string>
   <string name="pref_select_apps_summary">Odaberi Aplikacije koje će se usmjeriti kroz Tor</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Jelöld be ezt négyzetet, ha fogalmad sincs arról, hogy miről beszélünk)</string>
   <string name="wizard_transproxy_none">Nincs</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">A Tor Transzparens Proxyzásának engedélyezése a Wifi és az USB Tetherelt eszközök felé (újraindítást igényel)</string>
+  <string name="pref_transparent_tethering_summary">A Tor Transzparens Proxyzásának engedélyezése a Wi-Fi és az USB Tetherelt eszközök felé (újraindítást igényel)</string>
   <string name="button_grant_superuser">Superuser hozzáférés kérése</string>
   <string name="pref_select_apps">Alkalmazások kiválasztása</string>
   <string name="pref_select_apps_summary">Válassz alkalmazásokat, amik keresztül haladjanak a Tor-on</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Tandai box ini jika anda tidak tahu apa yang kita bicarakan)</string>
   <string name="wizard_transproxy_none">Tidak ada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wifi dan Perangkat Tether USB (diperlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wi-Fi dan Perangkat Tether USB (diperlukan restart)</string>
   <string name="button_grant_superuser">Meminta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk Mengerahkan Melalui Tor</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Tandai box ini jika anda tidak tahu apa yang kita bicarakan)</string>
   <string name="wizard_transproxy_none">Tidak ada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wifi dan Perangkat Tether USB (diperlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wi-Fi dan Perangkat Tether USB (diperlukan restart)</string>
   <string name="button_grant_superuser">Meminta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk Mengerahkan Melalui Tor</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Hakaðu í þennan reit ef þú hefur enga hugmynd um hvað við erum að tala)</string>
   <string name="wizard_transproxy_none">Ekkert</string>
   <string name="pref_transparent_tethering_title">Tor-netaðgangspunktur</string>
-  <string name="pref_transparent_tethering_summary">Leyfa gegnsæja milliþjónabeiningu á Tor fyrir tæki sem geta gefið netaaðgang í gegnum WiFi og USB  (þarfnast endurræsingar)</string>
+  <string name="pref_transparent_tethering_summary">Leyfa gegnsæja milliþjónabeiningu á Tor fyrir tæki sem geta gefið netaaðgang í gegnum Wi-Fi og USB  (þarfnast endurræsingar)</string>
   <string name="button_grant_superuser">Biðja um ofurnotandaréttindi</string>
   <string name="pref_select_apps">Veldu smáforrit</string>
   <string name="pref_select_apps_summary">Veldu smáforrit til að beina í gegnum Tor</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Seleziona questa casella se non hai idea di quello di cui stiamo parlando)</string>
   <string name="wizard_transproxy_none">Nessuno</string>
   <string name="pref_transparent_tethering_title">Tethering Tor</string>
-  <string name="pref_transparent_tethering_summary">Abilita il proxying trasparente di Tor per i dispositivi connessi in tethering via WiFi e USB (necessita di riavvio)</string>
+  <string name="pref_transparent_tethering_summary">Abilita il proxying trasparente di Tor per i dispositivi connessi in tethering via Wi-Fi e USB (necessita di riavvio)</string>
   <string name="button_grant_superuser">Richiede accesso superuser</string>
   <string name="pref_select_apps">Seleziona app</string>
   <string name="pref_select_apps_summary">Scegli le applicazioni da utilizzare attraverso Tor</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(何を言っているのかわからないときはここをチェックしてください)</string>
   <string name="wizard_transproxy_none">無し</string>
   <string name="pref_transparent_tethering_title">Torテザリング</string>
-  <string name="pref_transparent_tethering_summary">Tor透過プロクシをWifiかUSBテザリングされたデバイスに対して有効化(再起動が必要)</string>
+  <string name="pref_transparent_tethering_summary">Tor透過プロクシをWi-FiかUSBテザリングされたデバイスに対して有効化(再起動が必要)</string>
   <string name="button_grant_superuser">管理許可アクセスを要求します</string>
   <string name="pref_select_apps">アプリケーションを選択します</string>
   <string name="pref_select_apps_summary">Torを経由させるアプリを選択</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Atzīmējiet šo kastīti gadījumā ja Jums nav ne mazākās nojausmas par to, ko mēs te runājam)</string>
   <string name="wizard_transproxy_none">Neviens</string>
   <string name="pref_transparent_tethering_title">Tor valgošana</string>
-  <string name="pref_transparent_tethering_summary">Iespējot Tor Pārredzamo starpniekošanu Wifi\'m un USB valgošanas ierīcēm (nepieciešams pārstartēt)</string>
+  <string name="pref_transparent_tethering_summary">Iespējot Tor Pārredzamo starpniekošanu Wi-Fi\'m un USB valgošanas ierīcēm (nepieciešams pārstartēt)</string>
   <string name="button_grant_superuser">Pieprasīt superlietotāja piekļuvi</string>
   <string name="pref_select_apps">Izvēlēties lietotnes</string>
   <string name="pref_select_apps_summary">Izvēlēties lietotnes, lai maršrutētu caur Tor</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Селектирајте го ова поле ако не разбирате за што зборуваме)</string>
   <string name="wizard_transproxy_none">Ништо</string>
   <string name="pref_transparent_tethering_title">Tor поврзување</string>
-  <string name="pref_transparent_tethering_summary">Овозможи транспарентно проксирање на Tor за уреди поврзани преку Wifi и USB  (бара рестартирање)</string>
+  <string name="pref_transparent_tethering_summary">Овозможи транспарентно проксирање на Tor за уреди поврзани преку Wi-Fi и USB  (бара рестартирање)</string>
   <string name="button_grant_superuser">Барање за пристап до администратор на системот</string>
   <string name="pref_select_apps">Изберете апликации</string>
   <string name="pref_select_apps_summary">Одбери апликации кои ќе се поврзуваат преку Тор</string>

--- a/app/src/main/res/values-ms-rMY/strings.xml
+++ b/app/src/main/res/values-ms-rMY/strings.xml
@@ -97,7 +97,7 @@
   <string name="wizard_transproxy_hint">(Tanda kotak ini jika anda belen)</string>
   <string name="wizard_transproxy_none">Tiada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wifi dan USB Devices terikat (memerlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wi-Fi dan USB Devices terikat (memerlukan restart)</string>
   <string name="button_grant_superuser">Minta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk dihalakan melalui Tor</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -101,7 +101,7 @@
   <string name="wizard_transproxy_hint">(Tanda kotak ini jika anda belen)</string>
   <string name="wizard_transproxy_none">Tiada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wifi dan USB Devices terikat (memerlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wi-Fi dan USB Devices terikat (memerlukan restart)</string>
   <string name="button_grant_superuser">Minta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk dihalakan melalui Tor</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -277,7 +277,7 @@
   <string name="bridges_updated">Bridges bijgewerkt</string>
   <string name="restart_orbot_to_use_this_bridge_">Herstart Orbot om de wijzigingen in te schakelen</string>
   <string name="menu_qr">QR-codes</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Als je mobiele netwerk Tor actief blokkeert, kan je een \'bridge-server\' gebruiken als alternatieve toegang. SELECTEER een van de opties om te configureren en te testen..,.</string>
+  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Als je mobiele netwerk Tor actief blokkeert, kan je een \'bridge-server\' gebruiken als alternatieve toegang. SELECTEER een van de opties om te configureren en te testen...</string>
   <string name="bridge_mode">Bridge-modus</string>
   <string name="get_bridges_email">E-mail</string>
   <string name="get_bridges_web">Web</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Vink dit aan als je geen idee hebt waarover we het hebben)</string>
   <string name="wizard_transproxy_none">Geen</string>
   <string name="pref_transparent_tethering_title">Tor tetheren</string>
-  <string name="pref_transparent_tethering_summary">Schakel Tor transparante proxy voor WiFi en USB-getheterde toestellen in (vereist herstart)</string>
+  <string name="pref_transparent_tethering_summary">Schakel Tor transparante proxy voor Wi-Fi en USB-getheterde toestellen in (vereist herstart)</string>
   <string name="button_grant_superuser">Vraag Superuser-toegang aan</string>
   <string name="pref_select_apps">Kies applicaties</string>
   <string name="pref_select_apps_summary">Kies applicaties om via Tor te draaien</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Sprawdź tutaj, jeśli nie masz pojęcia o czym mówimy)</string>
   <string name="wizard_transproxy_none">Brak</string>
   <string name="pref_transparent_tethering_title">Przywiązywanie Tora</string>
-  <string name="pref_transparent_tethering_summary">Włącz Transparentne Proxy Tora dla Wifi i USB (wymaga restartu)</string>
+  <string name="pref_transparent_tethering_summary">Włącz Transparentne Proxy Tora dla Wi-Fi i USB (wymaga restartu)</string>
   <string name="button_grant_superuser">Żądanie dostępu Superużytkownika</string>
   <string name="pref_select_apps">Wybierz aplikacje</string>
   <string name="pref_select_apps_summary">Wybierz aplikacje do przejścia przez Tor</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Selecione esta caixa se você não souber do que estamos falando)</string>
   <string name="wizard_transproxy_none">Nenhum</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente para Tor Dispositivos de Toque Wifi e Usb (requer reinicialização)</string>
+  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente para Tor Dispositivos de Toque Wi-Fi e Usb (requer reinicialização)</string>
   <string name="button_grant_superuser">Acesso Superusuário Requerido</string>
   <string name="pref_select_apps">Selecionar Apps</string>
   <string name="pref_select_apps_summary">Escolha as Apps para Rotearem Através do Tor</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Bifeaza asta daca nu ai idee despre ce vorbim)</string>
   <string name="wizard_transproxy_none">Nimic</string>
   <string name="pref_transparent_tethering_title">Partajarea conexiunii Tor</string>
-  <string name="pref_transparent_tethering_summary">Activeaza proxy transparent pentru conexiuni partajate prin WiFi si USB (necesita restart)</string>
+  <string name="pref_transparent_tethering_summary">Activeaza proxy transparent pentru conexiuni partajate prin Wi-Fi si USB (necesita restart)</string>
   <string name="button_grant_superuser">Cere acces Superuser</string>
   <string name="pref_select_apps">Selecteaza aplicatii</string>
   <string name="pref_select_apps_summary">Alege aplicatii care sa foloseasca Tor</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -98,7 +98,7 @@
   <string name="wizard_transproxy_hint">(ඔබට අප සදහන් කල කරුණු පිළිබද අවබෝධයක් නොමැති නම් මෙම කොටුව සලකුණු කරන්න)</string>
   <string name="wizard_transproxy_none">කිසිවක් නොමැත</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Wifi හා USB Tethered උපාංග සදහා Tor පාරදෘශ්‍ය නියුතු සේවාව සබල කරන්න (නැවත ආරම්භ කිරීමක් අවශ්‍යවේ)</string>
+  <string name="pref_transparent_tethering_summary">Wi-Fi හා USB Tethered උපාංග සදහා Tor පාරදෘශ්‍ය නියුතු සේවාව සබල කරන්න (නැවත ආරම්භ කිරීමක් අවශ්‍යවේ)</string>
   <string name="button_grant_superuser">සුපිරි පරිශීලකයාගේ ප්‍රවේශය ඉල්ලන්න </string>
   <string name="pref_select_apps">යොමුන් තෝරාගන්න </string>
   <string name="pref_select_apps_summary">Tor හරහා යැවීමට යොමුන් තෝරාගන්න </string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Zaškrtnite toto pole, pokiaľ netušíte o čom rozprávame)</string>
   <string name="wizard_transproxy_none">Žiadny</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Povoliť Tor transparentné proxy pre zariadenia pripojené cez Wifi alebo USB (vyžaduje reštart)</string>
+  <string name="pref_transparent_tethering_summary">Povoliť Tor transparentné proxy pre zariadenia pripojené cez Wi-Fi alebo USB (vyžaduje reštart)</string>
   <string name="button_grant_superuser">Vyžiadať prístup Superpoužívateľa</string>
   <string name="pref_select_apps">Vybrať aplikácie</string>
   <string name="pref_select_apps_summary">Vybrať aplikácie, ktoré majú byť smerované cez Tor</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Markera denna om du inte har någon aning om vad vi pratar om)</string>
   <string name="wizard_transproxy_none">Ingen</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Aktivera Tor Transparent Proxy för Wifi och USB Thetered Enheter (omstart krävs)</string>
+  <string name="pref_transparent_tethering_summary">Aktivera Tor Transparent Proxy för Wi-Fi och USB Thetered Enheter (omstart krävs)</string>
   <string name="button_grant_superuser">Begär Superuser Tillgång</string>
   <string name="pref_select_apps">Välj Appar</string>
   <string name="pref_select_apps_summary">Välj Appar att Leda Genom Tor</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -85,7 +85,7 @@
   <string name="wizard_transproxy_hint">(ติ๊กตัวเลือกนี้ถ้าคุณไม่เข้าใจเรื่องที่เรากำลังอธิบาย)</string>
   <string name="wizard_transproxy_none">ไม่มี</string>
   <string name="pref_transparent_tethering_title">การเชื่อมต่อพ่วงผ่าน Tor</string>
-  <string name="pref_transparent_tethering_summary">เปิดใช้งานพร็อกซีล่องหนของ Tor ให้อุปกรณ์อื่นที่เชื่อมผ่าน Wifi และ USB (ต้องเริ่มใหม่)</string>
+  <string name="pref_transparent_tethering_summary">เปิดใช้งานพร็อกซีล่องหนของ Tor ให้อุปกรณ์อื่นที่เชื่อมผ่าน Wi-Fi และ USB (ต้องเริ่มใหม่)</string>
   <string name="button_grant_superuser">ร้องขอการเข้าถึงสิทธิ์ Superuser</string>
   <string name="pref_select_apps">เลือกโปรแกรม</string>
   <string name="pref_select_apps_summary">เลือกโปรแกรมที่จะให้เชื่อมต่อผ่าน Tor</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -107,7 +107,7 @@
   <string name="wizard_transproxy_hint">(Lagyan ng check ang box na ito kung wala kang alam sa sinasabi namin)</string>
   <string name="wizard_transproxy_none">Wala</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">I-enable ang Tor Transparent Proxying para sa Wifi at USB Tethered Devices (kailangan mag restart)</string>
+  <string name="pref_transparent_tethering_summary">I-enable ang Tor Transparent Proxying para sa Wi-Fi at USB Tethered Devices (kailangan mag restart)</string>
   <string name="button_grant_superuser">Humiling ng Superuser Access</string>
   <string name="pref_select_apps">Pumili ng Apps</string>
   <string name="pref_select_apps_summary">Pumili ng Apps para i-route sa Tor</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Hãy chọn ô này nếu bạn không hiểu những gì chúng tôi đang nói)</string>
   <string name="wizard_transproxy_none">Không có</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Kích hoạt proxy Tor trong suốt để dùng cho WiFi/USB Tethering (cần khởi động lại)</string>
+  <string name="pref_transparent_tethering_summary">Kích hoạt proxy Tor trong suốt để dùng cho Wi-Fi/USB Tethering (cần khởi động lại)</string>
   <string name="button_grant_superuser">Yều cầu truy cập root</string>
   <string name="pref_select_apps">Chọn ứng dụng</string>
   <string name="pref_select_apps_summary">Chọn những ứng dụng mà bạn muốn kết nối qua Tor</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -120,7 +120,7 @@ Tor帮助你避开那些威胁到你的隐私，重要信息和社交关系的�
   <string name="wizard_transproxy_hint">（如果不明白这里所说的问题，请选择该选项）</string>
   <string name="wizard_transproxy_none">无</string>
   <string name="pref_transparent_tethering_title">Tor 网络共享</string>
-  <string name="pref_transparent_tethering_summary">对 Wifi 和 USB 网络共享设备启用透明代理（需重新启动）</string>
+  <string name="pref_transparent_tethering_summary">对 Wi-Fi 和 USB 网络共享设备启用透明代理（需重新启动）</string>
   <string name="button_grant_superuser">请求 Superuser 访问权限</string>
   <string name="pref_select_apps">选择应用程序</string>
   <string name="pref_select_apps_summary">选择通过 Tor 连接网络的应用程序</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">（假如你不知道我們在說什麽，請選中該選擇框）</string>
   <string name="wizard_transproxy_none">無</string>
   <string name="pref_transparent_tethering_title">Tor 網路分享</string>
-  <string name="pref_transparent_tethering_summary">讓 Tor 的透明代理也適用到從 Wifi 和 USB 分享本機網路的裝置(需要重新啟動)</string>
+  <string name="pref_transparent_tethering_summary">讓 Tor 的透明代理也適用到從 Wi-Fi 和 USB 分享本機網路的裝置(需要重新啟動)</string>
   <string name="button_grant_superuser">要求 Superuser 權限</string>
   <string name="pref_select_apps">選擇應用程式</string>
   <string name="pref_select_apps_summary">選擇要繞經 Tor 的應用程式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,7 +117,7 @@
     <string name="wizard_transproxy_hint">(Check this box if you have no idea what we are talking about)</string>
     <string name="wizard_transproxy_none">None</string>
     <string name="pref_transparent_tethering_title">Tor Tethering</string>
-    <string name="pref_transparent_tethering_summary">Enable Tor Transparent Proxying for Wifi and USB Tethered Devices (requires restart)</string>
+    <string name="pref_transparent_tethering_summary">Enable Tor Transparent Proxying for Wi-Fi and USB Tethered Devices (requires restart)</string>
     <string name="button_grant_superuser">Request Superuser Access</string>
     <string name="pref_select_apps">Select Apps</string>
     <string name="pref_select_apps_summary">Choose Apps to Route Through Tor</string>
@@ -253,7 +253,7 @@
 
     <string name="menu_verify_browser">Browser</string>
   <string name="pref_open_proxy_on_all_interfaces_title">Open Proxy on All Interfaces</string>
-  <string name="pref_open_proxy_on_all_interfaces_summary">Allow Wifi peers, tethered devices and anyone else who can connect to your IP, to access Tor</string>
+  <string name="pref_open_proxy_on_all_interfaces_summary">Allow Wi-Fi peers, tethered devices and anyone else who can connect to your IP, to access Tor</string>
 
     <string name="permission_manage_tor_label">Manage Tor</string>
     <string name="permission_manage_tor_description">Enable this app to control the Tor service</string>

--- a/orbotservice/src/main/res/values-az/strings.xml
+++ b/orbotservice/src/main/res/values-az/strings.xml
@@ -118,7 +118,7 @@
   <string name="wizard_transproxy_hint">(Dediklərimizdən heç biri haqqında xəbərin yoxdursa, qutunu işarələ)</string>
   <string name="wizard_transproxy_none">Heç biri</string>
   <string name="pref_transparent_tethering_title">Tor-un Son Həddi</string>
-  <string name="pref_transparent_tethering_summary">Wifi və USB ilə Bağlanan Cihazlar üçün Tor Şəffaf Proksiləməni Aktivləşdir (cihazın yenidən yüklənməsini tələb edir)</string>
+  <string name="pref_transparent_tethering_summary">Wi-Fi və USB ilə Bağlanan Cihazlar üçün Tor Şəffaf Proksiləməni Aktivləşdir (cihazın yenidən yüklənməsini tələb edir)</string>
   <string name="button_grant_superuser">Superistifadəçi Giriş Tələbi</string>
   <string name="pref_select_apps">Aplikasiya Seç</string>
   <string name="pref_select_apps_summary">Tor vasitəsilə açılması üçün Aplikasiya seç</string>

--- a/orbotservice/src/main/res/values-bg/strings.xml
+++ b/orbotservice/src/main/res/values-bg/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Избери тази опция ако нямаш представа за какво става въпрос)</string>
   <string name="wizard_transproxy_none">Нищо</string>
   <string name="pref_transparent_tethering_title">Тетъринг през Тор</string>
-  <string name="pref_transparent_tethering_summary">Включи Прозрачно Тор Проксифициране през Wifi и USB (изисква рестартирване)</string>
+  <string name="pref_transparent_tethering_summary">Включи Прозрачно Тор Проксифициране през Wi-Fi и USB (изисква рестартирване)</string>
   <string name="button_grant_superuser">Изискай достъп на Суперпотребител</string>
   <string name="pref_select_apps">Избери приложения</string>
   <string name="pref_select_apps_summary">Избрери приложения за използване през Тор</string>

--- a/orbotservice/src/main/res/values-ca/strings.xml
+++ b/orbotservice/src/main/res/values-ca/strings.xml
@@ -100,7 +100,7 @@
   <string name="wizard_transproxy_hint">(Marqueu aquesta casella si no teniu ni idea del que estem parlant)</string>
   <string name="wizard_transproxy_none">Cap</string>
   <string name="pref_transparent_tethering_title">Compartició de xarxa amb Tor</string>
-  <string name="pref_transparent_tethering_summary">Activa el servidor intermediari transparent de Tor pels dispositius connectats a través de la compartició de xarxa via Wifi o USB (cal reiniciar)</string>
+  <string name="pref_transparent_tethering_summary">Activa el servidor intermediari transparent de Tor pels dispositius connectats a través de la compartició de xarxa via Wi-Fi o USB (cal reiniciar)</string>
   <string name="button_grant_superuser">Petició d\'accés de superusuari</string>
   <string name="pref_select_apps">Selecciona les apps</string>
   <string name="pref_select_apps_summary">Trieu quines apps s\'han de canalitzar a través de Tor</string>

--- a/orbotservice/src/main/res/values-cs-rCZ/strings.xml
+++ b/orbotservice/src/main/res/values-cs-rCZ/strings.xml
@@ -100,7 +100,7 @@
   <string name="wizard_transproxy_hint">(Povolte tuto volbu, pokud nemáte ponětí, o co se jedná)</string>
   <string name="wizard_transproxy_none">Žádné</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Povolit Tor transparentní proxy pro zařízení připojená přes Wifi a USB tethering (vyžaduje restart)</string>
+  <string name="pref_transparent_tethering_summary">Povolit Tor transparentní proxy pro zařízení připojená přes Wi-Fi a USB tethering (vyžaduje restart)</string>
   <string name="button_grant_superuser">Požadavek na Superuživatelský přístup</string>
   <string name="pref_select_apps">Vybrat aplikace</string>
   <string name="pref_select_apps_summary">Zvolte aplikace používající směrováni přes Tor</string>

--- a/orbotservice/src/main/res/values-da/strings.xml
+++ b/orbotservice/src/main/res/values-da/strings.xml
@@ -98,7 +98,7 @@
   <string name="wizard_transproxy_hint">(Check denne boks hvis du ikke aner hvad vi snakker om)</string>
   <string name="wizard_transproxy_none">Ingen</string>
   <string name="pref_transparent_tethering_title">Tor internet-hotspot</string>
-  <string name="pref_transparent_tethering_summary">Start Tor gennemsigtig proxy for Wifi og internetdeling over USB (kræver genstart)</string>
+  <string name="pref_transparent_tethering_summary">Start Tor gennemsigtig proxy for Wi-Fi og internetdeling over USB (kræver genstart)</string>
   <string name="button_grant_superuser">Anmod om Superuser adgang</string>
   <string name="pref_select_apps">Vælg apps</string>
   <string name="pref_select_apps_summary">Vælg apps som føres gennem Tor</string>

--- a/orbotservice/src/main/res/values-el/strings.xml
+++ b/orbotservice/src/main/res/values-el/strings.xml
@@ -99,7 +99,7 @@
   <string name="wizard_transproxy_hint">(Επιλέξτε αυτό το τετράγωνο αν δεν καταλαβαίνετε για τι πράγμα μιλάμε)</string>
   <string name="wizard_transproxy_none">Καμία</string>
   <string name="pref_transparent_tethering_title">Διασύνδεση Tor</string>
-  <string name="pref_transparent_tethering_summary">Ενεργοποίηση της Διαφανούς μεσολάβησης διακομιστή για συσκευές με WiFi και διασύνδεση USB (απαιτεί επανεκκίνηση)</string>
+  <string name="pref_transparent_tethering_summary">Ενεργοποίηση της Διαφανούς μεσολάβησης διακομιστή για συσκευές με Wi-Fi και διασύνδεση USB (απαιτεί επανεκκίνηση)</string>
   <string name="button_grant_superuser">Αίτημα Πρόσβασης Υπερχρήστη</string>
   <string name="pref_select_apps">Επιλογή εφαρμογών</string>
   <string name="pref_select_apps_summary">Επιλέξτε τις εφαρμογές που θα διέλθουν μέσω Tor</string>

--- a/orbotservice/src/main/res/values-es/strings.xml
+++ b/orbotservice/src/main/res/values-es/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Marque esta casilla si no tiene idea de qué estamos hablando)</string>
   <string name="wizard_transproxy_none">Ninguno</string>
   <string name="pref_transparent_tethering_title">Tor tethering</string>
-  <string name="pref_transparent_tethering_summary">Habilita la proxyficación transparente de Tor para dispositivos tethered (dispositivos móviles \"amarrados\", pasarela a Internet para otros dispositivos conectados a ellos mediante Wifi, USB o Bluetooth) -- (requiere reinicio)</string>
+  <string name="pref_transparent_tethering_summary">Habilita la proxyficación transparente de Tor para dispositivos tethered (dispositivos móviles \"amarrados\", pasarela a Internet para otros dispositivos conectados a ellos mediante Wi-Fi, USB o Bluetooth) -- (requiere reinicio)</string>
   <string name="button_grant_superuser">Solicitar permisos de superusuario</string>
   <string name="pref_select_apps">Seleccionar aplicaciones</string>
   <string name="pref_select_apps_summary">Escoja las aplicaciones a redirigir través de Tor</string>

--- a/orbotservice/src/main/res/values-et/strings.xml
+++ b/orbotservice/src/main/res/values-et/strings.xml
@@ -99,7 +99,7 @@
   <string name="wizard_transproxy_hint">(Klikkige sellele kastile kui teil pole õrna aimugi millest jutt käib)</string>
   <string name="wizard_transproxy_none">Puudub</string>
   <string name="pref_transparent_tethering_title">Tor lõastamine</string>
-  <string name="pref_transparent_tethering_summary">Luba Tor Läbipaistev Proxy WiFi ja USB lõastatud seadmetele (vajab uuestilaadimist)</string>
+  <string name="pref_transparent_tethering_summary">Luba Tor Läbipaistev Proxy Wi-Fi ja USB lõastatud seadmetele (vajab uuestilaadimist)</string>
   <string name="button_grant_superuser">Nõua Superkasutaja Juurdepääsu</string>
   <string name="pref_select_apps">Vali Rakendused</string>
   <string name="pref_select_apps_summary">Vali läbi Tor suunatavad rakendused</string>

--- a/orbotservice/src/main/res/values-eu/strings.xml
+++ b/orbotservice/src/main/res/values-eu/strings.xml
@@ -99,7 +99,7 @@
   <string name="wizard_transproxy_hint">(Gaituta utzi zertaz ari garez ulertzen ez baduzu)</string>
   <string name="wizard_transproxy_none">Bat ere ez</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Gaitu proxy gardena Wifi eta USB bidez Tethering-atutako gailuentzat (berrabiaraztea beharrezkoa)</string>
+  <string name="pref_transparent_tethering_summary">Gaitu proxy gardena Wi-Fi eta USB bidez Tethering-atutako gailuentzat (berrabiaraztea beharrezkoa)</string>
   <string name="button_grant_superuser">Supererabiltzaile sarrera eskatu</string>
   <string name="pref_select_apps">Aplikazioak hautatu</string>
   <string name="pref_select_apps_summary">Tor bidez bideratuko diren aplikazioak hautatu</string>

--- a/orbotservice/src/main/res/values-fi/strings.xml
+++ b/orbotservice/src/main/res/values-fi/strings.xml
@@ -112,7 +112,7 @@
   <string name="wizard_transproxy_hint">(Rastita tämä ruutu, jos et tiedä, mitä tarkoitamme)</string>
   <string name="wizard_transproxy_none">Ei mikään</string>
   <string name="pref_transparent_tethering_title">Tor-välityspalvelimena oleminen</string>
-  <string name="pref_transparent_tethering_summary">Salli Torin läpinäkyvä tiedonvälitys Wifille ja USB-välityspalvelimena oleville laitteille (vaatii uudelleenkäynnistyksen)</string>
+  <string name="pref_transparent_tethering_summary">Salli Torin läpinäkyvä tiedonvälitys Wi-Fille ja USB-välityspalvelimena oleville laitteille (vaatii uudelleenkäynnistyksen)</string>
   <string name="button_grant_superuser">Pyydä Superuser-oikeuksia</string>
   <string name="pref_select_apps">Valitse sovellukset</string>
   <string name="pref_select_apps_summary">Valitse Torin läpi reititettävät sovellukset</string>

--- a/orbotservice/src/main/res/values-gl/strings.xml
+++ b/orbotservice/src/main/res/values-gl/strings.xml
@@ -100,7 +100,7 @@
   <string name="wizard_transproxy_hint">(Marque esta caixa se non ten nin idea do que lle estamos a falar)</string>
   <string name="wizard_transproxy_none">Ningunha</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente Tor para dispositivos enlazados por Wifi ou USB (require reiniciar)</string>
+  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente Tor para dispositivos enlazados por Wi-Fi ou USB (require reiniciar)</string>
   <string name="button_grant_superuser">Pedir Acceso de Superusuario</string>
   <string name="pref_select_apps">Seleccionar Aplicativos</string>
   <string name="pref_select_apps_summary">Elixir Aplicativos a Enrutar a Través de Tor</string>

--- a/orbotservice/src/main/res/values-hr/strings.xml
+++ b/orbotservice/src/main/res/values-hr/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Stavite kvačicu ako nemate pojma o čemu pričamo)</string>
   <string name="wizard_transproxy_none">Ništa</string>
   <string name="pref_transparent_tethering_title">Tor Privezanje</string>
-  <string name="pref_transparent_tethering_summary">Omogući Tor Transparentni Proxy za Wifi i USB privezane uređaje (zahtijeva ponovno pokretanje)</string>
+  <string name="pref_transparent_tethering_summary">Omogući Tor Transparentni Proxy za Wi-Fi i USB privezane uređaje (zahtijeva ponovno pokretanje)</string>
   <string name="button_grant_superuser">Zatraži Pristup Superuser-u</string>
   <string name="pref_select_apps">Odaberi Aplikacije</string>
   <string name="pref_select_apps_summary">Odaberi Aplikacije koje će se usmjeriti kroz Tor</string>

--- a/orbotservice/src/main/res/values-hu/strings.xml
+++ b/orbotservice/src/main/res/values-hu/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Jelöld be ezt négyzetet, ha fogalmad sincs arról, hogy miről beszélünk)</string>
   <string name="wizard_transproxy_none">Nincs</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">A Tor Transzparens Proxyzásának engedélyezése a Wifi és az USB Tetherelt eszközök felé (újraindítást igényel)</string>
+  <string name="pref_transparent_tethering_summary">A Tor Transzparens Proxyzásának engedélyezése a Wi-Fi és az USB Tetherelt eszközök felé (újraindítást igényel)</string>
   <string name="button_grant_superuser">Superuser hozzáférés kérése</string>
   <string name="pref_select_apps">Alkalmazások kiválasztása</string>
   <string name="pref_select_apps_summary">Válassz alkalmazásokat, amik keresztül haladjanak a Tor-on</string>

--- a/orbotservice/src/main/res/values-id/strings.xml
+++ b/orbotservice/src/main/res/values-id/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Tandai box ini jika anda tidak tahu apa yang kita bicarakan)</string>
   <string name="wizard_transproxy_none">Tidak ada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wifi dan Perangkat Tether USB (diperlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wi-Fi dan Perangkat Tether USB (diperlukan restart)</string>
   <string name="button_grant_superuser">Meminta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk Mengerahkan Melalui Tor</string>

--- a/orbotservice/src/main/res/values-in-rID/strings.xml
+++ b/orbotservice/src/main/res/values-in-rID/strings.xml
@@ -115,7 +115,7 @@
   <string name="wizard_transproxy_hint">(Tandai box ini jika anda tidak tahu apa yang kita bicarakan)</string>
   <string name="wizard_transproxy_none">Tidak ada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wifi dan Perangkat Tether USB (diperlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Mengaktifkan Transparan Proxying Tor untuk Wi-Fi dan Perangkat Tether USB (diperlukan restart)</string>
   <string name="button_grant_superuser">Meminta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk Mengerahkan Melalui Tor</string>

--- a/orbotservice/src/main/res/values-is/strings.xml
+++ b/orbotservice/src/main/res/values-is/strings.xml
@@ -112,7 +112,7 @@
   <string name="wizard_transproxy_hint">(Hakaðu í þenna reit ef þú hefur enga hugmynd um hvað við erum að tala)</string>
   <string name="wizard_transproxy_none">Engin</string>
   <string name="pref_transparent_tethering_title">Tor Netaðgangspunktur</string>
-  <string name="pref_transparent_tethering_summary">Leyfa Tor Gegnsæja Proxýun fyrir WiFi og USB Tæki með Netaðgengi (þarfnast endurræsingar)</string>
+  <string name="pref_transparent_tethering_summary">Leyfa Tor Gegnsæja Proxýun fyrir Wi-Fi og USB Tæki með Netaðgengi (þarfnast endurræsingar)</string>
   <string name="button_grant_superuser">Biðja um Ofurnotandaréttindi</string>
   <string name="pref_select_apps">Velja Smáforrit</string>
   <string name="pref_select_apps_summary">Velja Smáforrit til að Beina í gegnum Tor</string>

--- a/orbotservice/src/main/res/values-it/strings.xml
+++ b/orbotservice/src/main/res/values-it/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Seleziona questa casella se non hai idea di quello di cui stiamo parlando)</string>
   <string name="wizard_transproxy_none">Nessuno</string>
   <string name="pref_transparent_tethering_title">Tethering Tor</string>
-  <string name="pref_transparent_tethering_summary">Abilita il proxying trasparente di Tor per i dispositivi connessi in tethering via WiFi e USB (necessita di riavvio)</string>
+  <string name="pref_transparent_tethering_summary">Abilita il proxying trasparente di Tor per i dispositivi connessi in tethering via Wi-Fi e USB (necessita di riavvio)</string>
   <string name="button_grant_superuser">Richiede accesso superuser</string>
   <string name="pref_select_apps">Seleziona app</string>
   <string name="pref_select_apps_summary">Scegli le applicazioni da utilizzare attraverso Tor</string>

--- a/orbotservice/src/main/res/values-ja/strings.xml
+++ b/orbotservice/src/main/res/values-ja/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(何を言っているのかわからないときはここをチェックしてください)</string>
   <string name="wizard_transproxy_none">無し</string>
   <string name="pref_transparent_tethering_title">Torテザリング</string>
-  <string name="pref_transparent_tethering_summary">Tor透過プロクシをWifiかUSBテザリングされたデバイスに対して有効化(再起動が必要)</string>
+  <string name="pref_transparent_tethering_summary">Tor透過プロクシをWi-FiかUSBテザリングされたデバイスに対して有効化(再起動が必要)</string>
   <string name="button_grant_superuser">管理許可アクセスを要求します</string>
   <string name="pref_select_apps">アプリケーションを選択します</string>
   <string name="pref_select_apps_summary">Torを経由させるアプリを選択</string>

--- a/orbotservice/src/main/res/values-lv/strings.xml
+++ b/orbotservice/src/main/res/values-lv/strings.xml
@@ -112,7 +112,7 @@
   <string name="wizard_transproxy_hint">(Atzīmējiet šo kastīti gadījumā ja Jums nav ne mazākās nojausmas par to, ko mēs te runājam)</string>
   <string name="wizard_transproxy_none">Neviens</string>
   <string name="pref_transparent_tethering_title">Tor valgošana</string>
-  <string name="pref_transparent_tethering_summary">Iespējot Tor Pārredzamo starpniekošanu Wifi\'m un USB valgošanas ierīcēm (nepieciešams pārstartēt)</string>
+  <string name="pref_transparent_tethering_summary">Iespējot Tor Pārredzamo starpniekošanu Wi-Fi\'m un USB valgošanas ierīcēm (nepieciešams pārstartēt)</string>
   <string name="button_grant_superuser">Pieprasīt superlietotāja piekļuvi</string>
   <string name="pref_select_apps">Izvēlēties lietotnes</string>
   <string name="pref_select_apps_summary">Izvēlēties lietotnes, lai maršrutētu caur Tor</string>

--- a/orbotservice/src/main/res/values-mk/strings.xml
+++ b/orbotservice/src/main/res/values-mk/strings.xml
@@ -112,7 +112,7 @@
   <string name="wizard_transproxy_hint">(Селектирајте го ова поле ако не разбирате за што зборуваме)</string>
   <string name="wizard_transproxy_none">Ништо</string>
   <string name="pref_transparent_tethering_title">Tor поврзување</string>
-  <string name="pref_transparent_tethering_summary">Овозможи транспарентно проксирање на Tor за уреди поврзани преку Wifi и USB  (бара рестартирање)</string>
+  <string name="pref_transparent_tethering_summary">Овозможи транспарентно проксирање на Tor за уреди поврзани преку Wi-Fi и USB  (бара рестартирање)</string>
   <string name="button_grant_superuser">Барање за пристап до администратор на системот</string>
   <string name="pref_select_apps">Изберете апликации</string>
   <string name="pref_select_apps_summary">Одбери апликации кои ќе се поврзуваат преку Тор</string>

--- a/orbotservice/src/main/res/values-ms-rMY/strings.xml
+++ b/orbotservice/src/main/res/values-ms-rMY/strings.xml
@@ -97,7 +97,7 @@
   <string name="wizard_transproxy_hint">(Tanda kotak ini jika anda belen)</string>
   <string name="wizard_transproxy_none">Tiada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wifi dan USB Devices terikat (memerlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wi-Fi dan USB Devices terikat (memerlukan restart)</string>
   <string name="button_grant_superuser">Minta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk dihalakan melalui Tor</string>

--- a/orbotservice/src/main/res/values-ms/strings.xml
+++ b/orbotservice/src/main/res/values-ms/strings.xml
@@ -103,7 +103,7 @@
   <string name="wizard_transproxy_hint">(Tanda kotak ini jika anda belen)</string>
   <string name="wizard_transproxy_none">Tiada</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wifi dan USB Devices terikat (memerlukan restart)</string>
+  <string name="pref_transparent_tethering_summary">Membolehkan Proxying Telus Tor untuk Wi-Fi dan USB Devices terikat (memerlukan restart)</string>
   <string name="button_grant_superuser">Minta Akses Superuser</string>
   <string name="pref_select_apps">Pilih Aplikasi</string>
   <string name="pref_select_apps_summary">Pilih Aplikasi untuk dihalakan melalui Tor</string>

--- a/orbotservice/src/main/res/values-nb/strings.xml
+++ b/orbotservice/src/main/res/values-nb/strings.xml
@@ -108,7 +108,7 @@
   <string name="wizard_transproxy_hint">(Marker denne boksen hvis du ikke har noen anelse om hva vi snakker om)</string>
   <string name="wizard_transproxy_none">Ingen</string>
   <string name="pref_transparent_tethering_title">Tor-deling</string>
-  <string name="pref_transparent_tethering_summary">Aktiver Tor Transparent proxyer for WiFi, og USB delte enheter (krever omstart)</string>
+  <string name="pref_transparent_tethering_summary">Aktiver Tor Transparent proxyer for Wi-Fi, og USB delte enheter (krever omstart)</string>
   <string name="button_grant_superuser">Be om Superbruker tilgang</string>
   <string name="pref_select_apps">Velg applikasjoner</string>
   <string name="pref_select_apps_summary">Velg applikasjoner som skal rutes gjennom Tor</string>

--- a/orbotservice/src/main/res/values-nl/strings.xml
+++ b/orbotservice/src/main/res/values-nl/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Vink dit aan als je geen idee hebt waarover we het hebben)</string>
   <string name="wizard_transproxy_none">Geen</string>
   <string name="pref_transparent_tethering_title">Tor tetheren</string>
-  <string name="pref_transparent_tethering_summary">Schakel Tor transparante proxy voor WiFi en USB-getheterde toestellen in (vereist herstart)</string>
+  <string name="pref_transparent_tethering_summary">Schakel Tor transparante proxy voor Wi-Fi en USB-getheterde toestellen in (vereist herstart)</string>
   <string name="button_grant_superuser">Vraag Superuser-toegang aan</string>
   <string name="pref_select_apps">Kies applicaties</string>
   <string name="pref_select_apps_summary">Kies applicaties om via Tor te draaien</string>

--- a/orbotservice/src/main/res/values-pl/strings.xml
+++ b/orbotservice/src/main/res/values-pl/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Sprawdź tutaj, jeśli nie masz pojęcia o czym mówimy)</string>
   <string name="wizard_transproxy_none">Brak</string>
   <string name="pref_transparent_tethering_title">Przywiązywanie Tora</string>
-  <string name="pref_transparent_tethering_summary">Włącz Transparentne Proxy Tora dla Wifi i USB (wymaga restartu)</string>
+  <string name="pref_transparent_tethering_summary">Włącz Transparentne Proxy Tora dla Wi-Fi i USB (wymaga restartu)</string>
   <string name="button_grant_superuser">Żądanie dostępu Superużytkownika</string>
   <string name="pref_select_apps">Wybierz aplikacje</string>
   <string name="pref_select_apps_summary">Wybierz aplikacje do przejścia przez Tor</string>

--- a/orbotservice/src/main/res/values-pt-rBR/strings.xml
+++ b/orbotservice/src/main/res/values-pt-rBR/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Selecione esta caixa se você não souber do que estamos falando)</string>
   <string name="wizard_transproxy_none">Nenhum</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente para Tor Dispositivos de Toque Wifi e Usb (requer reinicialização)</string>
+  <string name="pref_transparent_tethering_summary">Habilitar Proxy Transparente para Tor Dispositivos de Toque Wi-Fi e Usb (requer reinicialização)</string>
   <string name="button_grant_superuser">Acesso Superusuário Requerido</string>
   <string name="pref_select_apps">Selecionar Apps</string>
   <string name="pref_select_apps_summary">Escolha as Apps para Rotearem Através do Tor</string>

--- a/orbotservice/src/main/res/values-ro/strings.xml
+++ b/orbotservice/src/main/res/values-ro/strings.xml
@@ -100,7 +100,7 @@
   <string name="wizard_transproxy_hint">(Bifeaza asta daca nu ai idee despre ce vorbim)</string>
   <string name="wizard_transproxy_none">Nimic</string>
   <string name="pref_transparent_tethering_title">Partajarea conexiunii Tor</string>
-  <string name="pref_transparent_tethering_summary">Activeaza proxy transparent pentru conexiuni partajate prin WiFi si USB (necesita restart)</string>
+  <string name="pref_transparent_tethering_summary">Activeaza proxy transparent pentru conexiuni partajate prin Wi-Fi si USB (necesita restart)</string>
   <string name="button_grant_superuser">Cere acces Superuser</string>
   <string name="pref_select_apps">Selecteaza aplicatii</string>
   <string name="pref_select_apps_summary">Alege aplicatii care sa foloseasca Tor</string>

--- a/orbotservice/src/main/res/values-si-rLK/strings.xml
+++ b/orbotservice/src/main/res/values-si-rLK/strings.xml
@@ -97,7 +97,7 @@
   <string name="wizard_transproxy_hint">(ඔබට අප සදහන් කල කරුණු පිළිබද අවබෝධයක් නොමැති නම් මෙම කොටුව සලකුණු කරන්න)</string>
   <string name="wizard_transproxy_none">කිසිවක් නොමැත</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Wifi හා USB Tethered උපාංග සදහා Tor පාරදෘශ්‍ය නියුතු සේවාව සබල කරන්න (නැවත ආරම්භ කිරීමක් අවශ්‍යවේ)</string>
+  <string name="pref_transparent_tethering_summary">Wi-Fi හා USB Tethered උපාංග සදහා Tor පාරදෘශ්‍ය නියුතු සේවාව සබල කරන්න (නැවත ආරම්භ කිරීමක් අවශ්‍යවේ)</string>
   <string name="button_grant_superuser">සුපිරි පරිශීලකයාගේ ප්‍රවේශය ඉල්ලන්න </string>
   <string name="pref_select_apps">යොමුන් තෝරාගන්න </string>
   <string name="pref_select_apps_summary">Tor හරහා යැවීමට යොමුන් තෝරාගන්න </string>

--- a/orbotservice/src/main/res/values-sv/strings.xml
+++ b/orbotservice/src/main/res/values-sv/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Markera denna om du inte har någon aning om vad vi pratar om)</string>
   <string name="wizard_transproxy_none">Ingen</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Aktivera Tor Transparent Proxy för Wifi och USB Thetered Enheter (omstart krävs)</string>
+  <string name="pref_transparent_tethering_summary">Aktivera Tor Transparent Proxy för Wi-Fi och USB Thetered Enheter (omstart krävs)</string>
   <string name="button_grant_superuser">Begär Superuser Tillgång</string>
   <string name="pref_select_apps">Välj Appar</string>
   <string name="pref_select_apps_summary">Välj Appar att Leda Genom Tor</string>

--- a/orbotservice/src/main/res/values-th/strings.xml
+++ b/orbotservice/src/main/res/values-th/strings.xml
@@ -85,7 +85,7 @@
   <string name="wizard_transproxy_hint">(ติ๊กตัวเลือกนี้ถ้าคุณไม่เข้าใจเรื่องที่เรากำลังอธิบาย)</string>
   <string name="wizard_transproxy_none">ไม่มี</string>
   <string name="pref_transparent_tethering_title">การเชื่อมต่อพ่วงผ่าน Tor</string>
-  <string name="pref_transparent_tethering_summary">เปิดใช้งานพร็อกซีล่องหนของ Tor ให้อุปกรณ์อื่นที่เชื่อมผ่าน Wifi และ USB (ต้องเริ่มใหม่)</string>
+  <string name="pref_transparent_tethering_summary">เปิดใช้งานพร็อกซีล่องหนของ Tor ให้อุปกรณ์อื่นที่เชื่อมผ่าน Wi-Fi และ USB (ต้องเริ่มใหม่)</string>
   <string name="button_grant_superuser">ร้องขอการเข้าถึงสิทธิ์ Superuser</string>
   <string name="pref_select_apps">เลือกโปรแกรม</string>
   <string name="pref_select_apps_summary">เลือกโปรแกรมที่จะให้เชื่อมต่อผ่าน Tor</string>

--- a/orbotservice/src/main/res/values-tl/strings.xml
+++ b/orbotservice/src/main/res/values-tl/strings.xml
@@ -109,7 +109,7 @@
   <string name="wizard_transproxy_hint">(Lagyan ng check ang box na ito kung wala kang alam sa sinasabi namin)</string>
   <string name="wizard_transproxy_none">Wala</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">I-enable ang Tor Transparent Proxying para sa Wifi at USB Tethered Devices (kailangan mag restart)</string>
+  <string name="pref_transparent_tethering_summary">I-enable ang Tor Transparent Proxying para sa Wi-Fi at USB Tethered Devices (kailangan mag restart)</string>
   <string name="button_grant_superuser">Humiling ng Superuser Access</string>
   <string name="pref_select_apps">Pumili ng Apps</string>
   <string name="pref_select_apps_summary">Pumili ng Apps para i-route sa Tor</string>

--- a/orbotservice/src/main/res/values-vi/strings.xml
+++ b/orbotservice/src/main/res/values-vi/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Hãy chọn ô này nếu bạn không hiểu những gì chúng tôi đang nói)</string>
   <string name="wizard_transproxy_none">Không có</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Kích hoạt proxy Tor trong suốt để dùng cho WiFi/USB Tethering (cần khởi động lại)</string>
+  <string name="pref_transparent_tethering_summary">Kích hoạt proxy Tor trong suốt để dùng cho Wi-Fi/USB Tethering (cần khởi động lại)</string>
   <string name="button_grant_superuser">Yều cầu truy cập root</string>
   <string name="pref_select_apps">Chọn ứng dụng</string>
   <string name="pref_select_apps_summary">Chọn những ứng dụng mà bạn muốn kết nối qua Tor</string>

--- a/orbotservice/src/main/res/values-zh-rCN/strings.xml
+++ b/orbotservice/src/main/res/values-zh-rCN/strings.xml
@@ -122,7 +122,7 @@ Tor帮助你避开那些威胁到你的隐私，重要信息和社交关系的�
   <string name="wizard_transproxy_hint">（如果不明白这里所说的问题，请选择该选项）</string>
   <string name="wizard_transproxy_none">无</string>
   <string name="pref_transparent_tethering_title">Tor 网络共享</string>
-  <string name="pref_transparent_tethering_summary">对 Wifi 和 USB 网络共享设备启用透明代理（需重新启动）</string>
+  <string name="pref_transparent_tethering_summary">对 Wi-Fi 和 USB 网络共享设备启用透明代理（需重新启动）</string>
   <string name="button_grant_superuser">请求 Superuser 访问权限</string>
   <string name="pref_select_apps">选择应用程序</string>
   <string name="pref_select_apps_summary">选择通过 Tor 连接网络的应用程序</string>

--- a/orbotservice/src/main/res/values/strings.xml
+++ b/orbotservice/src/main/res/values/strings.xml
@@ -117,7 +117,7 @@
   <string name="wizard_transproxy_hint">(Check this box if you have no idea what we are talking about)</string>
   <string name="wizard_transproxy_none">None</string>
   <string name="pref_transparent_tethering_title">Tor Tethering</string>
-  <string name="pref_transparent_tethering_summary">Enable Tor Transparent Proxying for Wifi and USB Tethered Devices (requires restart)</string>
+  <string name="pref_transparent_tethering_summary">Enable Tor Transparent Proxying for Wi-Fi and USB Tethered Devices (requires restart)</string>
   <string name="button_grant_superuser">Request Superuser Access</string>
   <string name="pref_select_apps">Select Apps</string>
   <string name="pref_select_apps_summary">Choose Apps to Route Through Tor</string>


### PR DESCRIPTION
Things Addressed Here:

- The License dialog was read from the file without any newlines causing it to be crammed and have its hyperlinks 404.
- Some tiny string fixes (..,. appeared in some spots, and also Wi-Fi was referred to by an incorrect variation of Wi-Fi in a good number of places in the app)

The about dialog had a lot of broken URLs and words stuck together because it is partially populated by the [LICENSE](https://github.com/n8fr8/orbot/blob/master/LICENSE) file which was read in `OrbotMainActivity`'s `readFromAssets(Context, String)`. The issue here is that the file is read with `BufferedReader`'s [`readLine()`](https://docs.oracle.com/javase/7/docs/api/java/io/BufferedReader.html#readLine()) which terminates strings at a line feed or carriage return. The fix was to simply append a linefeed after every line the `BuferedReader` reads (these newlines are later transformed into `<br/>` elements when the About dialog is getting configured). 

It's easy to see what I mean via these screenshots:

![license-bad](https://user-images.githubusercontent.com/22125581/36747119-21700934-1bc2-11e8-8478-b7e932ad8ac2.png)

You can see in the first URL the "If" from the next sentence is squished against it causing users to have a 404 when they click on it.

![license-better](https://user-images.githubusercontent.com/22125581/36747126-23fcb6ca-1bc2-11e8-9101-6efa79ce118f.png)

With the linefeed fix we no longer have broken URLs and it's a bit easier to read too.

I also changed Wifi into Wi-Fi 