### PR TITLE
Removed Outdated FAQ in README

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,6 @@ is reasonably secure, but please ensure you read the instructions and
 configure it properly. Learn more at https://torproject.org/
 
 Tor Frequently Asked Questions:
-        https://wiki.torproject.org/noreply/TheOnionRouter/TorFAQ
         https://www.torproject.org/faq.html.en
 
 ***********************************************


### PR DESCRIPTION
The link on https://wiki.torproject.org/noreply/TheOnionRouter/TorFAQ says 

> This FAQ has been migrated to ​General FAQ. The answers in this FAQ may be old, incorrect, or obsolete.

 It tells visitors to see the other FAQ that is already linked in the README