### PR TITLE
Settings UI Improvements

### DIFF
--- a/app/src/main/java/org/torproject/android/settings/SettingsPreferences.java
+++ b/app/src/main/java/org/torproject/android/settings/SettingsPreferences.java
@@ -5,34 +5,26 @@ package org.torproject.android.settings;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
-import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
 
-import org.torproject.android.OrbotApp;
 import org.torproject.android.R;
 import org.torproject.android.service.util.Prefs;
-import org.torproject.android.service.util.TorServiceUtils;
 
-import java.util.Locale;
-
-
-public class SettingsPreferences 
-		extends PreferenceActivity  {
+public class SettingsPreferences
+        extends PreferenceActivity {
     private static final String TAG = "SettingsPreferences";
 
-	private ListPreference prefLocale = null;
-	
+    private ListPreference prefLocale = null;
+
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.preferences);
         getPreferenceManager().setSharedPreferencesMode(Context.MODE_MULTI_PROCESS);
-        SharedPreferences prefs = TorServiceUtils.getSharedPrefs(getApplicationContext());
 
         prefLocale = (ListPreference) findPreference("pref_default_locale");
         Languages languages = Languages.get(this);
@@ -46,21 +38,17 @@ public class SettingsPreferences
                 Prefs.setDefaultLocale(language);
                 LocaleHelper.setLocale(getApplicationContext(), language);
                 Intent intentResult = new Intent();
-                intentResult.putExtra("locale",language);
-                setResult(RESULT_OK,intentResult);
+                intentResult.putExtra("locale", language);
+                setResult(RESULT_OK, intentResult);
                 finish();
                 return false;
             }
         });
-
     }
-
 
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(LocaleHelper.onAttach(base));
     }
-
-
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,7 +136,7 @@
     <string name="pref_proxy_title">Outbound Network Proxy (Optional)</string>
 
     <string name="pref_proxy_type_title">Outbound Proxy Type</string>
-    <string name="pref_proxy_type_summary">Protocol to use for proxy server: HTTP, HTTPS, Socks4, Socks5</string>
+    <string name="pref_proxy_type_summary">Protocol to use for proxy server: HTTP, HTTPS, SOCKS4, SOCKS5</string>
     <string name="pref_proxy_type_dialog">Enter Proxy Type</string>
 
     <string name="pref_proxy_host_title">Outbound Proxy Host</string>
@@ -206,7 +206,7 @@
     <string name="enter_localhost_ports_for_hidden_services">enter localhost ports for hidden services</string>
     <string name="hidden_service_ports">Hidden Service Ports</string>
     <string name="the_addressable_name_for_your_hidden_service_generated_automatically_">the addressable name for your hidden service (generated automatically)</string>
-    <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">enable debug log to output (must use adb or aLogCat to view)</string>
+    <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">Enable debug log to output (must use adb or aLogcat to view)</string>
     <string name="project_home">Project Home(s): </string>
     <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="the_tor_license">The Tor License</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -118,7 +118,6 @@
             android:title="@string/use_bridges" />
 
         <EditTextPreference
-            android:defaultValue=""
             android:dialogTitle="@string/enter_bridge_addresses"
             android:inputType="textMultiLine|textNoSuggestions"
             android:key="pref_bridges_list"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,268 +1,270 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-<PreferenceCategory android:title="@string/pref_general_group">
-<CheckBoxPreference 
-android:defaultValue="true" 
-android:key="pref_start_boot"
-android:title="@string/pref_start_boot_title"
-android:summary="@string/pref_start_boot_summary"
-android:enabled="true"/>
+    <PreferenceCategory android:title="@string/pref_general_group">
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="pref_start_boot"
+            android:summary="@string/pref_start_boot_summary"
+            android:title="@string/pref_start_boot_title" />
 
-<CheckBoxPreference
-android:defaultValue="true" 
-android:key="pref_persistent_notifications"
-android:summary="@string/pref_use_persistent_notifications"
-android:enabled="true" 
-android:title="@string/pref_use_persistent_notifications_title"/>
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="pref_persistent_notifications"
+            android:summary="@string/pref_use_persistent_notifications"
+            android:title="@string/pref_use_persistent_notifications_title" />
 
-<CheckBoxPreference
-android:defaultValue="true" 
-android:key="pref_expanded_notifications"
-android:summary="@string/pref_use_expanded_notifications"
-android:enabled="true" 
-android:title="@string/pref_use_expanded_notifications_title"/>
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="pref_expanded_notifications"
+            android:summary="@string/pref_use_expanded_notifications"
+            android:title="@string/pref_use_expanded_notifications_title" />
 
-<CheckBoxPreference
-android:defaultValue="true" 
-android:key="pref_allow_background_starts"
-android:summary="@string/pref_allow_background_starts_summary"
-android:title="@string/pref_allow_background_starts_title"/>
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="pref_allow_background_starts"
+            android:summary="@string/pref_allow_background_starts_summary"
+            android:title="@string/pref_allow_background_starts_title" />
 
-<CheckBoxPreference
-android:defaultValue="false"
-android:key="pref_open_proxy_on_all_interfaces"
-android:summary="@string/pref_open_proxy_on_all_interfaces_summary"
-android:title="@string/pref_open_proxy_on_all_interfaces_title"/>
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_open_proxy_on_all_interfaces"
+            android:summary="@string/pref_open_proxy_on_all_interfaces_summary"
+            android:title="@string/pref_open_proxy_on_all_interfaces_title" />
 
- <ListPreference android:title="@string/set_locale_title"
-   android:key="pref_default_locale"
-   android:summary="@string/set_locale_summary"
-   android:defaultValue="en">
- </ListPreference>
+        <ListPreference
+            android:defaultValue="en"
+            android:key="pref_default_locale"
+            android:summary="@string/set_locale_summary"
+            android:title="@string/set_locale_title"/>
 
-</PreferenceCategory>
-<!--
-<PreferenceCategory android:title="@string/pref_trans_proxy_group">
+    </PreferenceCategory>
+    <!--
+    <PreferenceCategory android:title="@string/pref_trans_proxy_group">
 
-<CheckBoxPreference 
-android:defaultValue="false" 
-android:key="has_root"
-android:title="@string/pref_has_root"
-android:summary="@string/pref_has_root_summary"
-android:enabled="true"/>
-    
-<CheckBoxPreference 
-android:defaultValue="false" 
-android:key="pref_transparent"
-android:title="@string/pref_trans_proxy_title"
-android:summary="@string/pref_trans_proxy_summary"
-android:enabled="true"/>
+    <CheckBoxPreference
+    android:defaultValue="false"
+    android:key="has_root"
+    android:title="@string/pref_has_root"
+    android:summary="@string/pref_has_root_summary"
+    android:enabled="true"/>
 
-<CheckBoxPreference
-android:defaultValue="false" 
-android:key="pref_transparent_all"
-android:summary="@string/pref_transparent_all_summary"
-android:enabled="true" 
-android:title="@string/pref_transparent_all_title"/>
+    <CheckBoxPreference
+    android:defaultValue="false"
+    android:key="pref_transparent"
+    android:title="@string/pref_trans_proxy_title"
+    android:summary="@string/pref_trans_proxy_summary"
+    android:enabled="true"/>
 
-<Preference
-android:defaultValue="" 
-android:key="pref_transparent_app_list"
-android:title="@string/pref_select_apps"
-android:summary="@string/pref_select_apps_summary"
-android:enabled="true"/>
+    <CheckBoxPreference
+    android:defaultValue="false"
+    android:key="pref_transparent_all"
+    android:summary="@string/pref_transparent_all_summary"
+    android:enabled="true"
+    android:title="@string/pref_transparent_all_title"/>
 
-<CheckBoxPreference
-android:defaultValue="false" 
-android:key="pref_transparent_tethering"
-android:summary="@string/pref_transparent_tethering_summary"
-android:enabled="true"
-android:title="@string/pref_transparent_tethering_title"/>
+    <Preference
+    android:defaultValue=""
+    android:key="pref_transparent_app_list"
+    android:title="@string/pref_select_apps"
+    android:summary="@string/pref_select_apps_summary"
+    android:enabled="true"/>
 
-
-</PreferenceCategory>
--->
-<PreferenceCategory android:title="@string/pref_node_configuration"
- android:summary="@string/pref_node_configuration_summary">
- 
-<EditTextPreference android:key="pref_entrance_nodes"
-android:title="@string/pref_entrance_node"
-android:summary="@string/pref_entrance_node_summary"
-android:dialogTitle="@string/pref_entrance_node_dialog"
-/>
-<EditTextPreference android:key="pref_exit_nodes"
-android:title="@string/exit_nodes"
-android:summary="@string/fingerprints_nicks_countries_and_addresses_for_the_last_hop"
-android:dialogTitle="@string/enter_exit_nodes"
-/>
-<EditTextPreference android:key="pref_exclude_nodes"
-android:title="@string/exclude_nodes"
-android:summary="@string/fingerprints_nicks_countries_and_addresses_to_exclude"
-android:dialogTitle="@string/enter_exclude_nodes"
-/>
-
-<CheckBoxPreference android:defaultValue="false" 
-android:title="@string/strict_nodes" android:key="pref_strict_nodes" 
-android:summary="@string/use_only_these_specified_nodes"/>
-
-</PreferenceCategory> 
-<PreferenceCategory android:title="@string/bridges">
-
-<CheckBoxPreference android:defaultValue="false" 
-android:title="@string/use_bridges" android:key="pref_bridges_enabled" 
-android:summary="@string/enable_alternate_entrance_nodes_into_the_tor_network"/>
-
-<EditTextPreference android:key="pref_bridges_list"
-android:title="@string/bridges"
-android:summary="@string/ip_address_and_port_of_bridges"
-android:dialogTitle="@string/enter_bridge_addresses"
-android:defaultValue=""
-android:inputType="textMultiLine|textNoSuggestions"
-/>
-
-</PreferenceCategory>
-
-<PreferenceCategory android:title="@string/relays">
-<CheckBoxPreference android:key="pref_or"
-android:defaultValue="false"
-android:title="@string/relaying"
-android:summary="@string/enable_your_device_to_be_a_non_exit_relay"
-android:enabled="true"
-/>
-
-<EditTextPreference android:key="pref_or_port"
-android:defaultValue="9001"
-android:title="@string/relay_port"
-android:summary="@string/listening_port_for_your_tor_relay"
-android:dialogTitle="@string/enter_or_port"
-/>
-
-<EditTextPreference android:key="pref_or_nickname"
-android:defaultValue="OrbotRelay"
-android:title="@string/relay_nickname"
-android:summary="@string/the_nickname_for_your_tor_relay"
-android:dialogTitle="@string/enter_a_custom_relay_nickname"
-/>
-
-</PreferenceCategory>
-
-<PreferenceCategory android:title="ReachableAddresses">
-<CheckBoxPreference
-android:key="pref_reachable_addresses"
-android:defaultValue="false"
-android:title="@string/reachable_addresses"
-android:summary="@string/run_as_a_client_behind_a_firewall_with_restrictive_policies"
-android:enabled="true"></CheckBoxPreference>
-
-<EditTextPreference
-android:key="pref_reachable_addresses_ports"
-android:defaultValue="*:80,*:443"
-android:title="@string/reachable_ports"
-android:summary="@string/ports_reachable_behind_a_restrictive_firewall"
-android:dialogTitle="@string/enter_ports"
-/>
-</PreferenceCategory>
-
-<PreferenceCategory android:title="Isolation">
-<CheckBoxPreference
-android:key="pref_isolate_dest"
-android:defaultValue="false"
-android:title="@string/pref_isolate_dest"
-android:summary="@string/pref_isolate_dest_summary"
-android:enabled="true"></CheckBoxPreference>
-</PreferenceCategory>
-
-<PreferenceCategory android:title="ConnectionPadding">
-<CheckBoxPreference
-android:key="pref_connection_padding"
-android:defaultValue="false"
-android:title="@string/pref_connection_padding"
-android:summary="@string/pref_connection_padding_summary"
-android:enabled="true"></CheckBoxPreference>
-<CheckBoxPreference
-android:key="pref_reduced_connection_padding"
-android:defaultValue="true"
-android:title="@string/pref_reduced_connection_padding"
-android:summary="@string/pref_reduced_connection_padding_summary"
-android:enabled="true"></CheckBoxPreference>
-</PreferenceCategory>
+    <CheckBoxPreference
+    android:defaultValue="false"
+    android:key="pref_transparent_tethering"
+    android:summary="@string/pref_transparent_tethering_summary"
+    android:enabled="true"
+    android:title="@string/pref_transparent_tethering_title"/>
 
 
-<PreferenceCategory android:title="@string/pref_proxy_title">
-<EditTextPreference android:key="pref_proxy_type"
-android:title="@string/pref_proxy_type_title"
-android:summary="@string/pref_proxy_type_summary"
-android:dialogTitle="@string/pref_proxy_type_dialog"
-/>
-<EditTextPreference android:key="pref_proxy_host"
-android:title="@string/pref_proxy_host_title"
-android:summary="@string/pref_proxy_host_summary"
-android:dialogTitle="@string/pref_proxy_host_dialog"
-/>
-<EditTextPreference android:key="pref_proxy_port"
-android:title="@string/pref_proxy_port_title"
-android:summary="@string/pref_proxy_port_summary"
-android:dialogTitle="@string/pref_proxy_port_dialog"
-/>
+    </PreferenceCategory>
+    -->
+    <PreferenceCategory
+        android:summary="@string/pref_node_configuration_summary"
+        android:title="@string/pref_node_configuration">
 
-<EditTextPreference android:key="pref_proxy_username"
-android:title="@string/pref_proxy_username_title"
-android:summary="@string/pref_proxy_username_summary"
-android:dialogTitle="@string/pref_proxy_username_dialog"
-/>
-<EditTextPreference android:key="pref_proxy_password"
-android:title="@string/pref_proxy_password_title"
-android:summary="@string/pref_proxy_password_summary"
-android:dialogTitle="@string/pref_proxy_password_dialog"
-/>
-</PreferenceCategory>
+        <EditTextPreference
+            android:dialogTitle="@string/pref_entrance_node_dialog"
+            android:key="pref_entrance_nodes"
+            android:summary="@string/pref_entrance_node_summary"
+            android:title="@string/pref_entrance_node" />
+        <EditTextPreference
+            android:dialogTitle="@string/enter_exit_nodes"
+            android:key="pref_exit_nodes"
+            android:summary="@string/fingerprints_nicks_countries_and_addresses_for_the_last_hop"
+            android:title="@string/exit_nodes" />
+        <EditTextPreference
+            android:dialogTitle="@string/enter_exclude_nodes"
+            android:key="pref_exclude_nodes"
+            android:summary="@string/fingerprints_nicks_countries_and_addresses_to_exclude"
+            android:title="@string/exclude_nodes" />
 
-<PreferenceCategory android:title="Debug">
-    
-    <EditTextPreference android:key="pref_socks"
-android:title="@string/pref_socks_title"
-android:summary="@string/pref_socks_summary"
-android:dialogTitle="@string/pref_socks_dialog"
-android:defaultValue="9050"
-/>
-    
-      <EditTextPreference android:key="pref_transport"
-android:title="@string/pref_transport_title"
-android:summary="@string/pref_transport_summary"
-android:dialogTitle="@string/pref_transport_dialog"
-android:defaultValue="9040"
-/>
-      
-        <EditTextPreference android:key="pref_dnsport"
-android:title="@string/pref_dnsport_title"
-android:summary="@string/pref_dnsport_summary"
-android:dialogTitle="@string/pref_dnsport_dialog"
-android:defaultValue="5400"
-/>
-    
-  <EditTextPreference android:key="pref_custom_torrc"
-android:title="@string/pref_torrc_title"
-android:summary="@string/pref_torrc_summary"
-android:dialogTitle="@string/pref_torrc_dialog"
-/>
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_strict_nodes"
+            android:summary="@string/use_only_these_specified_nodes"
+            android:title="@string/strict_nodes" />
+
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/bridges">
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_bridges_enabled"
+            android:summary="@string/enable_alternate_entrance_nodes_into_the_tor_network"
+            android:title="@string/use_bridges" />
+
+        <EditTextPreference
+            android:defaultValue=""
+            android:dialogTitle="@string/enter_bridge_addresses"
+            android:inputType="textMultiLine|textNoSuggestions"
+            android:key="pref_bridges_list"
+            android:summary="@string/ip_address_and_port_of_bridges"
+            android:title="@string/bridges" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/relays">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_or"
+            android:summary="@string/enable_your_device_to_be_a_non_exit_relay"
+            android:title="@string/relaying" />
+
+        <EditTextPreference
+            android:defaultValue="9001"
+            android:dialogTitle="@string/enter_or_port"
+            android:key="pref_or_port"
+            android:summary="@string/listening_port_for_your_tor_relay"
+            android:title="@string/relay_port" />
+
+        <EditTextPreference
+            android:defaultValue="OrbotRelay"
+            android:dialogTitle="@string/enter_a_custom_relay_nickname"
+            android:key="pref_or_nickname"
+            android:summary="@string/the_nickname_for_your_tor_relay"
+            android:title="@string/relay_nickname" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="ReachableAddresses">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_reachable_addresses"
+            android:summary="@string/run_as_a_client_behind_a_firewall_with_restrictive_policies"
+            android:title="@string/reachable_addresses"/>
+
+        <EditTextPreference
+            android:defaultValue="*:80,*:443"
+            android:dialogTitle="@string/enter_ports"
+            android:key="pref_reachable_addresses_ports"
+            android:summary="@string/ports_reachable_behind_a_restrictive_firewall"
+            android:title="@string/reachable_ports" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Isolation">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_isolate_dest"
+            android:summary="@string/pref_isolate_dest_summary"
+            android:title="@string/pref_isolate_dest"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="ConnectionPadding">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_connection_padding"
+            android:summary="@string/pref_connection_padding_summary"
+            android:title="@string/pref_connection_padding"/>
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="pref_reduced_connection_padding"
+            android:summary="@string/pref_reduced_connection_padding_summary"
+            android:title="@string/pref_reduced_connection_padding"/>
+    </PreferenceCategory>
 
 
-<CheckBoxPreference
-android:key="pref_enable_logging"
-android:defaultValue="false"
-android:title="Debug Log"
-android:summary="@string/enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_"
-android:enabled="true"
-/>
+    <PreferenceCategory android:title="@string/pref_proxy_title">
+        <EditTextPreference
+            android:dialogTitle="@string/pref_proxy_type_dialog"
+            android:key="pref_proxy_type"
+            android:summary="@string/pref_proxy_type_summary"
+            android:title="@string/pref_proxy_type_title" />
+        <EditTextPreference
+            android:dialogTitle="@string/pref_proxy_host_dialog"
+            android:key="pref_proxy_host"
+            android:summary="@string/pref_proxy_host_summary"
+            android:title="@string/pref_proxy_host_title" />
+        <EditTextPreference
+            android:dialogTitle="@string/pref_proxy_port_dialog"
+            android:key="pref_proxy_port"
+            android:summary="@string/pref_proxy_port_summary"
+            android:title="@string/pref_proxy_port_title" />
+
+        <EditTextPreference
+            android:dialogTitle="@string/pref_proxy_username_dialog"
+            android:key="pref_proxy_username"
+            android:summary="@string/pref_proxy_username_summary"
+            android:title="@string/pref_proxy_username_title" />
+        <EditTextPreference
+            android:dialogTitle="@string/pref_proxy_password_dialog"
+            android:key="pref_proxy_password"
+            android:summary="@string/pref_proxy_password_summary"
+            android:title="@string/pref_proxy_password_title" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Debug">
+
+        <EditTextPreference
+            android:defaultValue="9050"
+            android:dialogTitle="@string/pref_socks_dialog"
+            android:key="pref_socks"
+            android:summary="@string/pref_socks_summary"
+            android:title="@string/pref_socks_title" />
+
+        <EditTextPreference
+            android:defaultValue="9040"
+            android:dialogTitle="@string/pref_transport_dialog"
+            android:key="pref_transport"
+            android:summary="@string/pref_transport_summary"
+            android:title="@string/pref_transport_title" />
+
+        <EditTextPreference
+            android:defaultValue="5400"
+            android:dialogTitle="@string/pref_dnsport_dialog"
+            android:key="pref_dnsport"
+            android:summary="@string/pref_dnsport_summary"
+            android:title="@string/pref_dnsport_title" />
+
+        <EditTextPreference
+            android:dialogTitle="@string/pref_torrc_dialog"
+            android:key="pref_custom_torrc"
+            android:summary="@string/pref_torrc_summary"
+            android:title="@string/pref_torrc_title" />
 
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_enable_logging"
+            android:summary="@string/enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_"
+            android:title="Debug Log" />
 
-<CheckBoxPreference
-android:defaultValue="true" 
-android:key="pref_disable_network"
-android:summary="@string/pref_disable_network_summary"
-android:enabled="true" 
-android:title="@string/pref_disable_network_title"/>
 
-</PreferenceCategory>
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="pref_disable_network"
+            android:summary="@string/pref_disable_network_summary"
+            android:title="@string/pref_disable_network_title" />
+
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,7 +38,7 @@
             android:defaultValue="en"
             android:key="pref_default_locale"
             android:summary="@string/set_locale_summary"
-            android:title="@string/set_locale_title"/>
+            android:title="@string/set_locale_title" />
 
     </PreferenceCategory>
     <!--
@@ -138,6 +138,7 @@
         <EditTextPreference
             android:defaultValue="9001"
             android:dialogTitle="@string/enter_or_port"
+            android:inputType="number"
             android:key="pref_or_port"
             android:summary="@string/listening_port_for_your_tor_relay"
             android:title="@string/relay_port" />
@@ -157,7 +158,7 @@
             android:enabled="true"
             android:key="pref_reachable_addresses"
             android:summary="@string/run_as_a_client_behind_a_firewall_with_restrictive_policies"
-            android:title="@string/reachable_addresses"/>
+            android:title="@string/reachable_addresses" />
 
         <EditTextPreference
             android:defaultValue="*:80,*:443"
@@ -173,7 +174,7 @@
             android:enabled="true"
             android:key="pref_isolate_dest"
             android:summary="@string/pref_isolate_dest_summary"
-            android:title="@string/pref_isolate_dest"/>
+            android:title="@string/pref_isolate_dest" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="ConnectionPadding">
@@ -182,13 +183,13 @@
             android:enabled="true"
             android:key="pref_connection_padding"
             android:summary="@string/pref_connection_padding_summary"
-            android:title="@string/pref_connection_padding"/>
+            android:title="@string/pref_connection_padding" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="pref_reduced_connection_padding"
             android:summary="@string/pref_reduced_connection_padding_summary"
-            android:title="@string/pref_reduced_connection_padding"/>
+            android:title="@string/pref_reduced_connection_padding" />
     </PreferenceCategory>
 
 
@@ -205,6 +206,7 @@
             android:title="@string/pref_proxy_host_title" />
         <EditTextPreference
             android:dialogTitle="@string/pref_proxy_port_dialog"
+            android:inputType="number"
             android:key="pref_proxy_port"
             android:summary="@string/pref_proxy_port_summary"
             android:title="@string/pref_proxy_port_title" />
@@ -226,6 +228,7 @@
         <EditTextPreference
             android:defaultValue="9050"
             android:dialogTitle="@string/pref_socks_dialog"
+            android:inputType="number"
             android:key="pref_socks"
             android:summary="@string/pref_socks_summary"
             android:title="@string/pref_socks_title" />
@@ -233,6 +236,7 @@
         <EditTextPreference
             android:defaultValue="9040"
             android:dialogTitle="@string/pref_transport_dialog"
+            android:inputType="number"
             android:key="pref_transport"
             android:summary="@string/pref_transport_summary"
             android:title="@string/pref_transport_title" />
@@ -240,6 +244,7 @@
         <EditTextPreference
             android:defaultValue="5400"
             android:dialogTitle="@string/pref_dnsport_dialog"
+            android:inputType="number"
             android:key="pref_dnsport"
             android:summary="@string/pref_dnsport_summary"
             android:title="@string/pref_dnsport_title" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -218,6 +218,7 @@
             android:title="@string/pref_proxy_username_title" />
         <EditTextPreference
             android:dialogTitle="@string/pref_proxy_password_dialog"
+            android:inputType="textPassword"
             android:key="pref_proxy_password"
             android:summary="@string/pref_proxy_password_summary"
             android:title="@string/pref_proxy_password_title" />
@@ -251,6 +252,7 @@
 
         <EditTextPreference
             android:dialogTitle="@string/pref_torrc_dialog"
+            android:inputType="textMultiLine|textNoSuggestions"
             android:key="pref_custom_torrc"
             android:summary="@string/pref_torrc_summary"
             android:title="@string/pref_torrc_title" />


### PR DESCRIPTION
- all preferences for setting a port use `inputType="number"` on their `EditTextPreference` now. 
- the proxy password `EditTextPreference` uses `inputType="password"` to give it dingbats 
- minor ui string updates on this screen:
  - socks4/5 --> SOCKS4/5
  - all preference summaries have similar capitalization 
  - aLocCat --> aLogcat

One thing I would have liked to change but did not is the `EditTextPreference` for proxy type. The user is supposed to enter one of {HTTP, HTTPS, SOCKS4, SOCKS5} but they can enter anything. It would make sense here to use a `ListPreference` instead of an `EditTextPreference`, however I did not make the change to one because user preference data could be lost when users update the app.

 For example, if the `entriesValue` set for the `ListPreference` is {"http", "https", "socks4", "socks5"} and a user had previously configured the preference `"pref_proxy_type"` with the  `EditTextPreference` to "HTTP" *(instead of "http")*, the `ListPreference` would be set to no value. It's particularly unfortunate, because we don't even care about the casing of the proxy type.