### PR TITLE
When the Tor log is open, pressing back will close it instead of Orbot

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -126,6 +126,8 @@ public class OrbotMainActivity extends AppCompatActivity
     private final static int REQUEST_SETTINGS = 0x9874;
     private final static int REQUEST_VPN_APPS_SELECT = 8889;
 
+    private final static int LOG_DRAWER_GRAVITY = Gravity.END;
+
     // message types for mStatusUpdateHandler
     private final static int STATUS_UPDATE = 1;
     private static final int MESSAGE_TRAFFIC_COUNT = 2;
@@ -284,7 +286,7 @@ public class OrbotMainActivity extends AppCompatActivity
         lblStatus.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mDrawer.openDrawer(Gravity.END);
+                mDrawer.openDrawer(LOG_DRAWER_GRAVITY);
             }
         });
 
@@ -563,6 +565,18 @@ public class OrbotMainActivity extends AppCompatActivity
 			//can happen on exit/shutdown
 		}
 	}
+
+
+    @Override
+    public void onBackPressed() {
+        // check to see if the log is open, if so close it
+        if (mDrawer.isDrawerOpen(LOG_DRAWER_GRAVITY)) {
+            mDrawer.closeDrawers();
+        }
+        else {
+            super.onBackPressed();
+        }
+    }
 
 	private void refreshVPNApps ()
     {


### PR DESCRIPTION
In order to close the log the user must swipe the screen from the far left all the way to the far right. When viewing the Tor log, I tend to press back to return to the main screen and become frustrated when the  app closes.