### PR TITLE
App sorting for TorifiedApps is case sensitive

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -130,7 +130,12 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
 
         Collections.sort(mApps,new Comparator<TorifiedApp>() {
             public int compare(TorifiedApp o1, TorifiedApp o2) {
-                if (o1.isTorified() == o2.isTorified()) return o1.getName().compareTo(o2.getName());
+                /* Some apps start with lowercase letters and without the sorting being case
+                   insensitive they'd appear at the end of the grid of apps, a position where users
+                   would likely not expect to find them.
+                 */
+                if (o1.isTorified() == o2.isTorified())
+                    return o1.getName().toUpperCase().compareTo(o2.getName().toUpperCase());
                 if (o1.isTorified()) return -1;
                 return 1;
             }

--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -135,7 +135,7 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
                    would likely not expect to find them.
                  */
                 if (o1.isTorified() == o2.isTorified())
-                    return o1.getName().toUpperCase().compareTo(o2.getName().toUpperCase());
+                    return o1.getName().compareToIgnoreCase(o2.getName());
                 if (o1.isTorified()) return -1;
                 return 1;
             }

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
@@ -133,7 +133,7 @@ public class TorifiedApp implements Comparable {
 	
 	@Override
 	public int compareTo(Object another) {
-		return this.toString().toUpperCase().compareTo(another.toString().toUpperCase());
+		return this.toString().compareToIgnoreCase(another.toString());
 	}
 	
 	@Override

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
@@ -133,8 +133,7 @@ public class TorifiedApp implements Comparable {
 	
 	@Override
 	public int compareTo(Object another) {
-		
-		return this.toString().compareTo(another.toString());
+		return this.toString().toUpperCase().compareTo(another.toString().toUpperCase());
 	}
 	
 	@Override


### PR DESCRIPTION
Lowercase apps are buried at the end of the sorted uppercase apps. This matches the behavior used by every Android launcher that I've used so far. Aside from a smoother UX, it's possible that a user might think Orbot is broken/not trust it if they think that the app they want to use the VPN with is missing.

![unsorted](https://user-images.githubusercontent.com/22125581/38751084-fe235d60-3f24-11e8-9b31-d887f7340b10.png)
