### PR TITLE
Update BUILD Instructions for armeabi-v7a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ orbotservice/src/main/libs/
 orbotservice/src/main/jniLibs/
 orbotservice/src/main/assets/armeabi/
 orbotservice/src/main/assets/x86/
+orbotservice/src/main/assets/armeabi-v7a

--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,8 @@ You then need to run "ndk-build" from:
 	zip assets/armeabi/pdnsd.mp3 libs/armeabi/pdnsd
 	mkdir -p assets/x86
 	zip assets/x86/pdnsd.mp3 libs/x86/pdnsd
+	mkdir -p assets/armeabi-v7a
+	zip assets/armeabi-v7a/pdnsd.mp3 libs/armeabi-v7a/pdnsd
 
 This isn't enough though and we'll now sew up the binary into a small package
 that will handle basic Tor controlling features.


### PR DESCRIPTION
There was nothing in the BUILD documentation file to describe zipping up the armeabi-v7a pdnsd shared library. 

Additionally, after zipping it, it was not ignored so I added it to `orbotservice`'s `.gitignore`