### PR TITLE
torrc: remove deprecated DNSListenAddress and obsolete WarnUnsafeSocks

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/TorService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorService.java
@@ -696,7 +696,6 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
         extraLines.append("SOCKSPort ").append(socksPortPref).append(isolate).append('\n');
         extraLines.append("SafeSocks 0").append('\n');
         extraLines.append("TestSocks 0").append('\n');
-        extraLines.append("WarnUnsafeSocks 1").append('\n');
     	if (Prefs.openProxyOnAllInterfaces())
     		extraLines.append("SocksListenAddress 0.0.0.0").append('\n');
 
@@ -716,10 +715,8 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
         String dnsPort = prefs.getString("pref_dnsport", TorServiceConstants.TOR_DNS_PORT_DEFAULT+"");
             
         extraLines.append("TransPort ").append(transPort).append('\n');
-    	extraLines.append("DNSPort ").append(dnsPort).append("\n");
+    	extraLines.append("DNSPort ").append(dnsPort).append('\n');
     	
-    	if (Prefs.useVpn())
-    		extraLines.append("DNSListenAddress 0.0.0.0").append('\n');
 
         extraLines.append("VirtualAddrNetwork 10.192.0.0/10").append('\n');
         extraLines.append("AutomapHostsOnResolve 1").append('\n');


### PR DESCRIPTION
While replacing DNSListenAddress with DNSPort (which warns if listening on 0.0.0.0) I noticed
https://github.com/n8fr8/orbot/blob/a608a964964506e52878ef55e5b500fd54af90fb/orbotservice/src/main/java/org/torproject/android/service/TorService.java#L721-L722

which doesn't seem necessary as pdnsd 
https://github.com/n8fr8/orbot/blob/a608a964964506e52878ef55e5b500fd54af90fb/orbotservice/src/main/res/values/pdnsd.xml#L4-L31
already communicates between VPN network and device localhost therefore another direct connection between VPN network and DNS is not required/used.

@n8fr8 Can you double check?