### PR TITLE
Expose IPv6 related options and enable IPv6 support

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -388,6 +388,10 @@
     <string name="pref_connection_padding_summary">Always enables connection padding to defend against some forms of traffic analysis. Default: auto</string>
     <string name="pref_reduced_connection_padding">Reduced connection padding</string>
     <string name="pref_reduced_connection_padding_summary">Closes relay connections sooner and sends less padding packets to reduce data and battery usage</string>
+    <string name="pref_prefer_ipv6">Prefer IPv6 connections</string>
+    <string name="pref_prefer_ipv6_summary">Tells exits that IPv6 addresses are preferred</string>
+    <string name="pref_disable_ipv4">Disable IPv4 connections</string>
+    <string name="pref_disable_ipv4_summary">Tells exits not to connect to IPv4 addresses</string>
     <string name="please_enable_vpn">Please activate the VPN mode to enable apps to use Tor</string>
     <string name="app_shortcuts">Tor-Enabled Apps</string>
     <string name="title_activity_bridge_wizard">BridgeWizardActivity</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -174,13 +174,25 @@
             android:title="@string/reachable_ports" />
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="Isolation">
+    <PreferenceCategory android:title="Connectivity">
         <CheckBoxPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="pref_isolate_dest"
             android:summary="@string/pref_isolate_dest_summary"
             android:title="@string/pref_isolate_dest" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="pref_prefer_ipv6"
+            android:summary="@string/pref_prefer_ipv6_summary"
+            android:title="@string/pref_prefer_ipv6" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_disable_ipv4"
+            android:summary="@string/pref_disable_ipv4_summary"
+            android:title="@string/pref_disable_ipv4" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="ConnectionPadding">
@@ -197,7 +209,6 @@
             android:summary="@string/pref_reduced_connection_padding_summary"
             android:title="@string/pref_reduced_connection_padding" />
     </PreferenceCategory>
-
 
     <PreferenceCategory android:title="@string/pref_proxy_title">
         <EditTextPreference

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
-        google()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
@@ -39,4 +39,7 @@ public interface OrbotConstants {
 	public final static String PREF_CONNECTION_PADDING = "pref_connection_padding";
 	public final static String PREF_REDUCED_CONNECTION_PADDING = "pref_reduced_connection_padding";
 
+	public final static String PREF_PREFER_IPV6 = "pref_prefer_ipv6";
+	public final static String PREF_DISABLE_IPV4 = "pref_disable_ipv4";
+
 }

--- a/orbotservice/src/main/java/org/torproject/android/service/TorService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorService.java
@@ -663,14 +663,14 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
         extraLines.append("HTTPTunnelPort ").append(mPortHTTP).append(isolate).append(ipv6Pref).append('\n');
 
 
-	if(prefs.getBoolean(OrbotConstants.PREF_CONNECTION_PADDING, false))
-	{
-		extraLines.append("ConnectionPadding 1").append('\n');
-	}
-	if(prefs.getBoolean(OrbotConstants.PREF_REDUCED_CONNECTION_PADDING, true))
-	{
-		extraLines.append("ReducedConnectionPadding 1").append('\n');
-	}
+        if(prefs.getBoolean(OrbotConstants.PREF_CONNECTION_PADDING, false))
+        {
+            extraLines.append("ConnectionPadding 1").append('\n');
+        }
+        if(prefs.getBoolean(OrbotConstants.PREF_REDUCED_CONNECTION_PADDING, true))
+        {
+            extraLines.append("ReducedConnectionPadding 1").append('\n');
+        }
 
         String transPort = prefs.getString("pref_transport", TorServiceConstants.TOR_TRANSPROXY_PORT_DEFAULT+"");
         String dnsPort = prefs.getString("pref_dnsport", TorServiceConstants.TOR_DNS_PORT_DEFAULT+"");

--- a/orbotservice/src/main/java/org/torproject/android/service/TorService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorService.java
@@ -641,16 +641,26 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
         String isolate = " ";
         if(prefs.getBoolean(OrbotConstants.PREF_ISOLATE_DEST, false))
         {
-            isolate += "IsolateDestAddr";
+            isolate += "IsolateDestAddr ";
+        }
+
+        String ipv6Pref = " IPv6Traffic ";
+        if(prefs.getBoolean(OrbotConstants.PREF_PREFER_IPV6, true))
+        {
+            ipv6Pref += "PreferIPv6 ";
+        }
+        if(prefs.getBoolean(OrbotConstants.PREF_DISABLE_IPV4, false))
+        {
+            ipv6Pref += "NoIPv4Traffic ";
         }
         
-        extraLines.append("SOCKSPort ").append(socksPortPref).append(isolate).append('\n');
+        extraLines.append("SOCKSPort ").append(socksPortPref).append(isolate).append(ipv6Pref).append('\n');
         extraLines.append("SafeSocks 0").append('\n');
         extraLines.append("TestSocks 0").append('\n');
     	if (Prefs.openProxyOnAllInterfaces())
     		extraLines.append("SocksListenAddress 0.0.0.0").append('\n');
 
-        extraLines.append("HTTPTunnelPort ").append(mPortHTTP).append(isolate).append('\n');
+        extraLines.append("HTTPTunnelPort ").append(mPortHTTP).append(isolate).append(ipv6Pref).append('\n');
 
 
 	if(prefs.getBoolean(OrbotConstants.PREF_CONNECTION_PADDING, false))


### PR DESCRIPTION
This is default as in Tor Browser, see https://trac.torproject.org/projects/tor/ticket/21269

\+ some other minor fixes